### PR TITLE
Add viewport meta tag for responsive layouts

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,6 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ page.title }}</title>
     <link rel="stylesheet" href="{{ site.baseurl }}/assets/style.css">
 </head>

--- a/_layouts/rule.html
+++ b/_layouts/rule.html
@@ -3,6 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ page.title }}</title>
     <link rel="stylesheet" href="{{ site.baseurl }}/assets/style.css">
 </head>

--- a/_layouts/rules-list.html
+++ b/_layouts/rules-list.html
@@ -3,6 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ page.title }}</title>
     <link rel="stylesheet" href="{{ site.baseurl }}/assets/style.css">
 </head>


### PR DESCRIPTION
## Summary
- Ensure pages scale correctly on mobile by adding a viewport meta tag to all Jekyll layout files.

## Testing
- ⚠️ `jekyll build` *(command not found: jekyll)*
- ⚠️ `playwright install chromium` *(download failed: server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c96e5e9083268c9bf1177fb02663