### PR TITLE
Fix Rule 6 link closing tag in FRAP index

### DIFF
--- a/frap.html
+++ b/frap.html
@@ -23,7 +23,7 @@ breadcrumb_parent_url: /
       <li><a href="{{ site.baseurl }}/frap/rule_4/">Rule 4. Appeal as of Right—When Taken</a></li>
       <li><a href="{{ site.baseurl }}/frap/rule_5/">Rule 5. Appeal by Permission</a></li>
       <li><em>Rule 5.1. Appeal by Leave under 28 U.S.C. §636(c)(5) (Abrogated 1998)</em></li>
-      <li><a href="{{ site.baseurl }}/frap/rule_6/">Rule 6. Appeal in a Bankruptcy Case from a Final Judgement, Order, or Decree of a District Court or Bankruptcy Appellate Panel<a></li>
+      <li><a href="{{ site.baseurl }}/frap/rule_6/">Rule 6. Appeal in a Bankruptcy Case from a Final Judgement, Order, or Decree of a District Court or Bankruptcy Appellate Panel</a></li>
       <li><a href="{{ site.baseurl }}/frap/rule_7/">Rule 7. Bond for Costs on Appeal in a Civil Case</a></li>
       <li><a href="{{ site.baseurl }}/frap/rule_8/">Rule 8. Stay or Injunction Pending Appeal</a></li>
       <li><a href="{{ site.baseurl }}/frap/rule_9/">Rule 9. Release in a Criminal Case</a></li>


### PR DESCRIPTION
## Summary
- close Rule 6 anchor tag in FRAP index to remove stray `<a>`

## Testing
- `tidy -qe frap.html`

------
https://chatgpt.com/codex/tasks/task_e_68c6c97090048326a73d2b274e63a1f2