### PR TITLE
refactor: move inline styles to stylesheet

### DIFF
--- a/404.html
+++ b/404.html
@@ -4,28 +4,19 @@ title: Page Not Found
 permalink: /404
 ---
 
-<div class="content-container" style="text-align: center;">
-  <h1 style="font-size: 2.5rem; color: #003366;">404 – Page Not Found</h1>
-  <p style="font-size: 1.1rem; color: #555; max-width: 600px; margin: 1rem auto 2rem;">
+<div class="content-container text-center">
+  <h1 class="error-title">404 – Page Not Found</h1>
+  <p class="error-message">
     Sorry, the page you're looking for doesn't exist or has been moved.
     If you typed the address manually, please check your spelling.
   </p>
 
   <!-- Optional image -->
   <img src="{{ site.baseurl }}/assets/lost-gavel.png" alt="Lost Gavel"
-    style="max-width: 300px; margin-bottom: 2rem;">
+    class="error-image">
 
   <div>
-    <a href="{{ site.baseurl }}/" style="
-      display: inline-block;
-      padding: 0.75rem 1.5rem;
-      background-color: #003366;
-      color: white;
-      text-decoration: none;
-      font-weight: bold;
-      border-radius: 6px;
-      transition: background-color 0.2s ease-in-out;
-    ">
+    <a href="{{ site.baseurl }}/" class="btn-primary">
       Return to Home
     </a>
   </div>

--- a/assets/style.css
+++ b/assets/style.css
@@ -14,6 +14,10 @@ main {
   margin: 0 auto;
 }
 
+.text-center {
+  text-align: center;
+}
+
 
 #docket-cards::-webkit-scrollbar {
   width: 6px;
@@ -117,6 +121,29 @@ main {
 .intro-column {
   max-width: 600px;
   flex: 1 1 350px;
+}
+
+.docs-controls {
+  margin-top: 1rem;
+}
+
+.form-select {
+  margin-top: 0.25rem;
+  padding: 0.4rem 0.6rem;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+}
+
+.form-input {
+  margin-top: 0.25rem;
+  padding: 0.4rem 0.8rem;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  width: 100%;
+}
+
+.doc-grid {
+  margin-top: 1.5rem;
 }
 
 .docket-columns {
@@ -813,6 +840,38 @@ html {
   background: #1e3a8a; /* subtle blue tone */
   color: white;
   text-decoration: none;
+}
+
+.btn-primary {
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  background-color: #003366;
+  color: white;
+  text-decoration: none;
+  font-weight: bold;
+  border-radius: 6px;
+  transition: background-color 0.2s ease-in-out;
+}
+
+.btn-primary:hover {
+  text-decoration: none;
+}
+
+.error-title {
+  font-size: 2.5rem;
+  color: #003366;
+}
+
+.error-message {
+  font-size: 1.1rem;
+  color: #555;
+  max-width: 600px;
+  margin: 1rem auto 2rem;
+}
+
+.error-image {
+  max-width: 300px;
+  margin-bottom: 2rem;
 }
 
 @media (max-width: 1024px) {

--- a/docs.html
+++ b/docs.html
@@ -12,11 +12,10 @@ show_breadcrumbs: false
   <p>You are not required to use these templates — they are merely provided for the convenience of those who need them.
   </p>
 
-  <div class="top-flex-wrapper" style="margin-top: 1rem;">
+  <div class="top-flex-wrapper docs-controls">
     <div class="intro-column">
       <label for="courtFilter"><strong>Filter by Court:</strong></label><br>
-      <select id="courtFilter"
-        style="margin-top: 0.25rem; padding: 0.4rem 0.6rem; border: 1px solid #ccc; border-radius: 6px;">
+      <select id="courtFilter" class="form-select">
         <option value="All">All Courts</option>
         <option value="Supreme Court">Supreme Court</option>
         <option value="District Court">District Court</option>
@@ -25,11 +24,11 @@ show_breadcrumbs: false
     <div class="intro-column">
       <label for="docSearch"><strong>Search templates:</strong></label><br>
       <input type="text" id="docSearch" placeholder="Search templates..."
-        style="margin-top: 0.25rem; padding: 0.4rem 0.8rem; border: 1px solid #ccc; border-radius: 6px; width: 100%;" />
+        class="form-input" />
     </div>
   </div>
 
-  <div id="docGrid" class="resource-grid" style="margin-top: 1.5rem;">
+  <div id="docGrid" class="resource-grid doc-grid">
     <!-- Cards injected by JS -->
   </div>
 </section>


### PR DESCRIPTION
## Summary
- replace inline style attributes in 404.html and docs.html with semantic classes
- add shared button, form, and error page styles in assets/style.css

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c971eb1c8326a63ccc1702940220