### PR TITLE
Add permalinks and plugin configuration for Jekyll site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,22 @@
+# Site title shown in the browser and templates
 title: USAR Legal Directory
+
+# Path the site is served from
 baseurl: "/legal-directory"
+
+# Base URL for generating absolute links
 url: "https://usarscotus.github.io"
+
+# Short description used in meta tags and feeds
 description: A directory of legal resources for the USAR Community on ROBLOX.
+
+# Markdown engine
 markdown: kramdown
+
+# Use directory-style URLs for cleaner links
+permalink: pretty
+
+# Enable Jekyll plugins
+plugins:
+  - jekyll-feed # Generate an Atom feed of site posts
+  - jekyll-seo-tag # Add SEO tags for better search engine visibility


### PR DESCRIPTION
## Summary
- document configuration settings with inline comments
- use pretty permalinks
- enable jekyll-feed and jekyll-seo-tag plugins

## Testing
- `jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68c6c9782acc8326b0e0e3f965b9d00d