### PR TITLE
Add help page with FAQs and navigation guidance

### DIFF
--- a/help.html
+++ b/help.html
@@ -1,0 +1,31 @@
+---
+layout: page
+title: Help
+permalink: /help/
+show_breadcrumbs: true
+breadcrumb_parent: "Legal Directory"
+breadcrumb_parent_url: /
+---
+
+<section class="help-section">
+  <h1>Frequently Asked Questions</h1>
+  <dl class="faq-list">
+    <dt>How do I find court rules?</dt>
+    <dd>Use the navigation links on the home page or the search bar to locate specific federal rules or court procedures.</dd>
+    <dt>Where can I access document templates?</dt>
+    <dd>Visit the <a href="{{ site.baseurl }}/docs/">Document Library</a> for templates and resources.</dd>
+    <dt>Who maintains this website?</dt>
+    <dd>The United States Supreme Court of USAR maintains the legal directory.</dd>
+  </dl>
+
+  <h2>Contact Information</h2>
+  <p>For assistance or to report an issue, join our Discord servers listed in the footer or email the court administrators at <a href="mailto:support@usaroblox.org">support@usaroblox.org</a>.</p>
+
+  <h2>Site Navigation Tips</h2>
+  <ul>
+    <li>Use the search bar at the top of each page to quickly locate rules or documents.</li>
+    <li>The breadcrumb trail at the top of the page helps you track your current location within the site.</li>
+    <li>Links in the footer provide quick access to related resources and support servers.</li>
+  </ul>
+</section>
+


### PR DESCRIPTION
## Summary
- Create Help page with FAQs, contact details, and navigation tips
- Ensure Help page includes breadcrumbs and permalink for `/help/`

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68c6d4eac25483268187ccbd502f71c1