### PR TITLE
Group FRCP rules by chapter

### DIFF
--- a/_frcp/rule_1.md
+++ b/_frcp/rule_1.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 1. Scope and Purpose"
+title: Rule 1. Scope and Purpose
 permalink: /frcp/rule_1/
 order: 1
+chapter: Title I. Scope of Rules; Form of Action
 ---
 
 These rules govern the procedure in all civil actions and proceedings in the United States district courts, except as stated in Rule 81 . They should be construed, administered, and employed by the court and the parties to secure the just, speedy, and inexpensive determination of every action and proceeding.

--- a/_frcp/rule_10.md
+++ b/_frcp/rule_10.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 10. Form of Pleadings"
+title: Rule 10. Form of Pleadings
 permalink: /frcp/rule_10/
 order: 10
+chapter: Title III. Pleadings and Motions
 ---
 
 (a) Caption; Names of Parties. Every pleading must have a caption with the court's name, a title, a file number, and a Rule 7(a) designation. The title of the complaint must name all the parties; the title of other pleadings, after naming the first party on each side, may refer generally to other parties.

--- a/_frcp/rule_11.md
+++ b/_frcp/rule_11.md
@@ -1,8 +1,10 @@
 ---
 layout: rule
-title: "Rule 11. Signing Pleadings, Motions, and Other Papers; Representations to the Court; Sanctions"
+title: Rule 11. Signing Pleadings, Motions, and Other Papers; Representations to the
+  Court; Sanctions
 permalink: /frcp/rule_11/
 order: 11
+chapter: Title III. Pleadings and Motions
 ---
 
 (a) Signature. Every pleading, written motion, and other paper must be signed by at least one attorney of record in the attorney's name—or by a party personally if the party is unrepresented. The paper must state the signer's address, e-mail address, and telephone number. Unless a rule or statute specifically states otherwise, a pleading need not be verified or accompanied by an affidavit. The court must strike an unsigned paper unless the omission is promptly corrected after being called to the attorney's or party's attention.

--- a/_frcp/rule_12.md
+++ b/_frcp/rule_12.md
@@ -1,8 +1,10 @@
 ---
 layout: rule
-title: "Rule 12. Defenses and Objections: When and How Presented; Motion for Judgment on the Pleadings; Consolidating Motions; Waiving Defenses; Pretrial Hearing"
+title: 'Rule 12. Defenses and Objections: When and How Presented; Motion for Judgment
+  on the Pleadings; Consolidating Motions; Waiving Defenses; Pretrial Hearing'
 permalink: /frcp/rule_12/
 order: 12
+chapter: Title III. Pleadings and Motions
 ---
 
 (a) Time to Serve a Responsive Pleading.

--- a/_frcp/rule_13.md
+++ b/_frcp/rule_13.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 13. Counterclaim and Crossclaim"
+title: Rule 13. Counterclaim and Crossclaim
 permalink: /frcp/rule_13/
 order: 13
+chapter: Title III. Pleadings and Motions
 ---
 
 (a) Compulsory Counterclaim.

--- a/_frcp/rule_14.md
+++ b/_frcp/rule_14.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 14. Third-Party Practice"
+title: Rule 14. Third-Party Practice
 permalink: /frcp/rule_14/
 order: 14
+chapter: Title III. Pleadings and Motions
 ---
 
 (a) When a Defending Party May Bring in a Third Party.

--- a/_frcp/rule_15.md
+++ b/_frcp/rule_15.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 15. Amended and Supplemental Pleadings"
+title: Rule 15. Amended and Supplemental Pleadings
 permalink: /frcp/rule_15/
 order: 15
+chapter: Title III. Pleadings and Motions
 ---
 
 (a) Amendments Before Trial.

--- a/_frcp/rule_16.md
+++ b/_frcp/rule_16.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 16. Pretrial Conferences; Scheduling; Management"
+title: Rule 16. Pretrial Conferences; Scheduling; Management
 permalink: /frcp/rule_16/
 order: 16
+chapter: Title III. Pleadings and Motions
 ---
 
 (a) Purposes of a Pretrial Conference. In any action, the court may order the attorneys and any unrepresented parties to appear for one or more pretrial conferences for such purposes as:

--- a/_frcp/rule_17.md
+++ b/_frcp/rule_17.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 17. Plaintiff and Defendant; Capacity; Public Officers"
+title: Rule 17. Plaintiff and Defendant; Capacity; Public Officers
 permalink: /frcp/rule_17/
 order: 17
+chapter: Title IV. Parties
 ---
 
 (a) Real Party in Interest.

--- a/_frcp/rule_18.md
+++ b/_frcp/rule_18.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 18. Joinder of Claims"
+title: Rule 18. Joinder of Claims
 permalink: /frcp/rule_18/
 order: 18
+chapter: Title IV. Parties
 ---
 
 (a) In General. A party asserting a claim, counterclaim, crossclaim, or third-party claim may join, as independent or alternative claims, as many claims as it has against an opposing party.

--- a/_frcp/rule_19.md
+++ b/_frcp/rule_19.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 19. Required Joinder of Parties"
+title: Rule 19. Required Joinder of Parties
 permalink: /frcp/rule_19/
 order: 19
+chapter: Title IV. Parties
 ---
 
 (a) Persons Required to Be Joined if Feasible.

--- a/_frcp/rule_2.md
+++ b/_frcp/rule_2.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 2. One Form of Action"
+title: Rule 2. One Form of Action
 permalink: /frcp/rule_2/
 order: 2
+chapter: Title I. Scope of Rules; Form of Action
 ---
 
 There is one form of action—the civil action.

--- a/_frcp/rule_20.md
+++ b/_frcp/rule_20.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 20. Permissive Joinder of Parties"
+title: Rule 20. Permissive Joinder of Parties
 permalink: /frcp/rule_20/
 order: 20
+chapter: Title IV. Parties
 ---
 
 (a) Persons Who May Join or Be Joined.

--- a/_frcp/rule_21.md
+++ b/_frcp/rule_21.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 21. Misjoinder and Nonjoinder of Parties"
+title: Rule 21. Misjoinder and Nonjoinder of Parties
 permalink: /frcp/rule_21/
 order: 21
+chapter: Title IV. Parties
 ---
 
 Misjoinder of parties is not a ground for dismissing an action. On motion or on its own, the court may at any time, on just terms, add or drop a party. The court may also sever any claim against a party.

--- a/_frcp/rule_22.md
+++ b/_frcp/rule_22.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 22. Interpleader"
+title: Rule 22. Interpleader
 permalink: /frcp/rule_22/
 order: 22
+chapter: Title IV. Parties
 ---
 
 (a) Grounds.

--- a/_frcp/rule_23.1.md
+++ b/_frcp/rule_23.1.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 23.1. Derivative Actions"
+title: Rule 23.1. Derivative Actions
 permalink: /frcp/rule_23.1/
 order: 23.1
+chapter: Title IV. Parties
 ---
 
 (a) Prerequisites. This rule applies when one or more shareholders or members of a corporation or an unincorporated association bring a derivative action to enforce a right that the corporation or association may properly assert but has failed to enforce. The derivative action may not be maintained if it appears that the plaintiff does not fairly and adequately represent the interests of shareholders or members who are similarly situated in enforcing the right of the corporation or association.

--- a/_frcp/rule_23.2.md
+++ b/_frcp/rule_23.2.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 23.2. Actions Relating to Unincorporated Associations"
+title: Rule 23.2. Actions Relating to Unincorporated Associations
 permalink: /frcp/rule_23.2/
 order: 23.2
+chapter: Title IV. Parties
 ---
 
 This rule applies to an action brought by or against the members of an unincorporated association as a class by naming certain members as representative parties. The action may be maintained only if it appears that those parties will fairly and adequately protect the interests of the association and its members. In conducting the action, the court may issue any appropriate orders corresponding with those in Rule 23(d) , and the procedure for settlement, voluntary dismissal, or compromise must correspond with the procedure in Rule 23(e) .

--- a/_frcp/rule_23.md
+++ b/_frcp/rule_23.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 23. Class Actions"
+title: Rule 23. Class Actions
 permalink: /frcp/rule_23/
 order: 23
+chapter: Title IV. Parties
 ---
 
 (a) Prerequisites. One or more members of a class may sue or be sued as representative parties on behalf of all members only if:

--- a/_frcp/rule_24.md
+++ b/_frcp/rule_24.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 24. Intervention"
+title: Rule 24. Intervention
 permalink: /frcp/rule_24/
 order: 24
+chapter: Title IV. Parties
 ---
 
 (a) Intervention of Right. On timely motion, the court must permit anyone to intervene who:

--- a/_frcp/rule_25.md
+++ b/_frcp/rule_25.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 25. Substitution of Parties"
+title: Rule 25. Substitution of Parties
 permalink: /frcp/rule_25/
 order: 25
+chapter: Title IV. Parties
 ---
 
 (a) Death.

--- a/_frcp/rule_26.md
+++ b/_frcp/rule_26.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 26. Duty to Disclose; General Provisions Governing Discovery"
+title: Rule 26. Duty to Disclose; General Provisions Governing Discovery
 permalink: /frcp/rule_26/
 order: 26
+chapter: Title V. Disclosures and Discovery
 ---
 
 (a) Required Disclosures.

--- a/_frcp/rule_27.md
+++ b/_frcp/rule_27.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 27. Depositions to Perpetuate Testimony"
+title: Rule 27. Depositions to Perpetuate Testimony
 permalink: /frcp/rule_27/
 order: 27
+chapter: Title V. Disclosures and Discovery
 ---
 
 (a) Before an Action Is Filed.

--- a/_frcp/rule_28.md
+++ b/_frcp/rule_28.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 28. Persons Before Whom Depositions May Be Taken"
+title: Rule 28. Persons Before Whom Depositions May Be Taken
 permalink: /frcp/rule_28/
 order: 28
+chapter: Title V. Disclosures and Discovery
 ---
 
 (a) Within the United States.

--- a/_frcp/rule_29.md
+++ b/_frcp/rule_29.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 29. Stipulations About Discovery Procedure"
+title: Rule 29. Stipulations About Discovery Procedure
 permalink: /frcp/rule_29/
 order: 29
+chapter: Title V. Disclosures and Discovery
 ---
 
 Unless the court orders otherwise, the parties may stipulate that:

--- a/_frcp/rule_3.md
+++ b/_frcp/rule_3.md
@@ -1,8 +1,10 @@
 ---
 layout: rule
-title: "Rule 3. Commencing an Action"
+title: Rule 3. Commencing an Action
 permalink: /frcp/rule_3/
 order: 3
+chapter: Title II. Commencing an Action; Service of Process, Pleadings, Motions, and
+  Orders
 ---
 
 A civil action is commenced by filing a complaint with the court.

--- a/_frcp/rule_30.md
+++ b/_frcp/rule_30.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 30. Depositions by Oral Examination"
+title: Rule 30. Depositions by Oral Examination
 permalink: /frcp/rule_30/
 order: 30
+chapter: Title V. Disclosures and Discovery
 ---
 
 (a) When a Deposition May Be Taken.

--- a/_frcp/rule_31.md
+++ b/_frcp/rule_31.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 31. Depositions by Written Questions"
+title: Rule 31. Depositions by Written Questions
 permalink: /frcp/rule_31/
 order: 31
+chapter: Title V. Disclosures and Discovery
 ---
 
 (a) When a Deposition May Be Taken.

--- a/_frcp/rule_32.md
+++ b/_frcp/rule_32.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 32. Using Depositions in Court Proceedings"
+title: Rule 32. Using Depositions in Court Proceedings
 permalink: /frcp/rule_32/
 order: 32
+chapter: Title V. Disclosures and Discovery
 ---
 
 (a) Using Depositions.

--- a/_frcp/rule_33.md
+++ b/_frcp/rule_33.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 33. Interrogatories to Parties"
+title: Rule 33. Interrogatories to Parties
 permalink: /frcp/rule_33/
 order: 33
+chapter: Title V. Disclosures and Discovery
 ---
 
 (a) In General.

--- a/_frcp/rule_34.md
+++ b/_frcp/rule_34.md
@@ -1,8 +1,10 @@
 ---
 layout: rule
-title: "Rule 34. Producing Documents, Electronically Stored Information, and Tangible Things, or Entering onto Land, for Inspection and Other Purposes"
+title: Rule 34. Producing Documents, Electronically Stored Information, and Tangible
+  Things, or Entering onto Land, for Inspection and Other Purposes
 permalink: /frcp/rule_34/
 order: 34
+chapter: Title V. Disclosures and Discovery
 ---
 
 (a) In General. A party may serve on any other party a request within the scope of Rule 26(b) :

--- a/_frcp/rule_35.md
+++ b/_frcp/rule_35.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 35. Physical and Mental Examinations"
+title: Rule 35. Physical and Mental Examinations
 permalink: /frcp/rule_35/
 order: 35
+chapter: Title V. Disclosures and Discovery
 ---
 
 (a) Order for an Examination.

--- a/_frcp/rule_36.md
+++ b/_frcp/rule_36.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 36. Requests for Admission"
+title: Rule 36. Requests for Admission
 permalink: /frcp/rule_36/
 order: 36
+chapter: Title V. Disclosures and Discovery
 ---
 
 (a) Scope and Procedure.

--- a/_frcp/rule_37.md
+++ b/_frcp/rule_37.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 37. Failure to Make Disclosures or to Cooperate in Discovery; Sanctions"
+title: Rule 37. Failure to Make Disclosures or to Cooperate in Discovery; Sanctions
 permalink: /frcp/rule_37/
 order: 37
+chapter: Title V. Disclosures and Discovery
 ---
 
 (a) Motion for an Order Compelling Disclosure or Discovery.

--- a/_frcp/rule_38.md
+++ b/_frcp/rule_38.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 38. Right to a Jury Trial; Demand"
+title: Rule 38. Right to a Jury Trial; Demand
 permalink: /frcp/rule_38/
 order: 38
+chapter: Title VI. Trials
 ---
 
 (a) Right Preserved. The right of trial by jury as declared by the Seventh Amendment to the Constitution—or as provided by a federal statute—is preserved to the parties inviolate.

--- a/_frcp/rule_39.md
+++ b/_frcp/rule_39.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 39. Trial by Jury or by the Court"
+title: Rule 39. Trial by Jury or by the Court
 permalink: /frcp/rule_39/
 order: 39
+chapter: Title VI. Trials
 ---
 
 (a) When a Demand Is Made. When a jury trial has been demanded under Rule 38 , the action must be designated on the docket as a jury action. The trial on all issues so demanded must be by jury unless:

--- a/_frcp/rule_4.1.md
+++ b/_frcp/rule_4.1.md
@@ -1,8 +1,10 @@
 ---
 layout: rule
-title: "Rule 4.1. Serving Other Process"
+title: Rule 4.1. Serving Other Process
 permalink: /frcp/rule_4.1/
 order: 4.1
+chapter: Title II. Commencing an Action; Service of Process, Pleadings, Motions, and
+  Orders
 ---
 
 (a) In General. Process—other than a summons under Rule 4 or a subpoena under Rule 45 —must be served by a United States marshal or deputy marshal or by a person specially appointed for that purpose. It may be served anywhere within the territorial limits of the state where the district court is located and, if authorized by a federal statute, beyond those limits. Proof of service must be made under Rule 4( l ) .

--- a/_frcp/rule_4.md
+++ b/_frcp/rule_4.md
@@ -1,8 +1,10 @@
 ---
 layout: rule
-title: "Rule 4. Summons"
+title: Rule 4. Summons
 permalink: /frcp/rule_4/
 order: 4
+chapter: Title II. Commencing an Action; Service of Process, Pleadings, Motions, and
+  Orders
 ---
 
 (a) Contents; Amendments.

--- a/_frcp/rule_40.md
+++ b/_frcp/rule_40.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 40. Scheduling Cases for Trial"
+title: Rule 40. Scheduling Cases for Trial
 permalink: /frcp/rule_40/
 order: 40
+chapter: Title VI. Trials
 ---
 
 Each court must provide by rule for scheduling trials. The court must give priority to actions entitled to priority by a federal statute.

--- a/_frcp/rule_41.md
+++ b/_frcp/rule_41.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 41. Dismissal of Actions"
+title: Rule 41. Dismissal of Actions
 permalink: /frcp/rule_41/
 order: 41
+chapter: Title VI. Trials
 ---
 
 (a) Voluntary Dismissal.

--- a/_frcp/rule_42.md
+++ b/_frcp/rule_42.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 42. Consolidation; Separate Trials"
+title: Rule 42. Consolidation; Separate Trials
 permalink: /frcp/rule_42/
 order: 42
+chapter: Title VI. Trials
 ---
 
 (a) Consolidation. If actions before the court involve a common question of law or fact, the court may:

--- a/_frcp/rule_43.md
+++ b/_frcp/rule_43.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 43. Taking Testimony"
+title: Rule 43. Taking Testimony
 permalink: /frcp/rule_43/
 order: 43
+chapter: Title VI. Trials
 ---
 
 (a) In Open Court. At trial, the witnesses’ testimony must be taken in open court unless a federal statute, the Federal Rules of Evidence , these rules, or other rules adopted by the Supreme Court provide otherwise. For good cause in compelling circumstances and with appropriate safeguards, the court may permit testimony in open court by contemporaneous transmission from a different location.

--- a/_frcp/rule_44.1.md
+++ b/_frcp/rule_44.1.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 44.1. Determining Foreign Law"
+title: Rule 44.1. Determining Foreign Law
 permalink: /frcp/rule_44.1/
 order: 44.1
+chapter: Title VI. Trials
 ---
 
 A party who intends to raise an issue about a foreign country's law must give notice by a pleading or other writing. In determining foreign law, the court may consider any relevant material or source, including testimony, whether or not submitted by a party or admissible under the Federal Rules of Evidence . The court's determination must be treated as a ruling on a question of law.

--- a/_frcp/rule_44.md
+++ b/_frcp/rule_44.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 44. Proving an Official Record"
+title: Rule 44. Proving an Official Record
 permalink: /frcp/rule_44/
 order: 44
+chapter: Title VI. Trials
 ---
 
 (a) Means of Proving.

--- a/_frcp/rule_45.md
+++ b/_frcp/rule_45.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 45. Subpoena"
+title: Rule 45. Subpoena
 permalink: /frcp/rule_45/
 order: 45
+chapter: Title VI. Trials
 ---
 
 (a) In General.

--- a/_frcp/rule_46.md
+++ b/_frcp/rule_46.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 46. Objecting to a Ruling or Order"
+title: Rule 46. Objecting to a Ruling or Order
 permalink: /frcp/rule_46/
 order: 46
+chapter: Title VI. Trials
 ---
 
 A formal exception to a ruling or order is unnecessary. When the ruling or order is requested or made, a party need only state the action that it wants the court to take or objects to, along with the grounds for the request or objection. Failing to object does not prejudice a party who had no opportunity to do so when the ruling or order was made.

--- a/_frcp/rule_47.md
+++ b/_frcp/rule_47.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 47. Selecting Jurors"
+title: Rule 47. Selecting Jurors
 permalink: /frcp/rule_47/
 order: 47
+chapter: Title VI. Trials
 ---
 
 (a) Examining Jurors. The court may permit the parties or their attorneys to examine prospective jurors or may itself do so. If the court examines the jurors, it must permit the parties or their attorneys to make any further inquiry it considers proper, or must itself ask any of their additional questions it considers proper.

--- a/_frcp/rule_48.md
+++ b/_frcp/rule_48.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 48. Number of Jurors; Verdict; Polling"
+title: Rule 48. Number of Jurors; Verdict; Polling
 permalink: /frcp/rule_48/
 order: 48
+chapter: Title VI. Trials
 ---
 
 (a) Number of Jurors. A jury must begin with at least 6 and no more than 12 members, and each juror must participate in the verdict unless excused under Rule 47(c) .

--- a/_frcp/rule_49.md
+++ b/_frcp/rule_49.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 49. Special Verdict; General Verdict and Questions"
+title: Rule 49. Special Verdict; General Verdict and Questions
 permalink: /frcp/rule_49/
 order: 49
+chapter: Title VI. Trials
 ---
 
 (a) Special Verdict.

--- a/_frcp/rule_5.1.md
+++ b/_frcp/rule_5.1.md
@@ -1,8 +1,10 @@
 ---
 layout: rule
-title: "Rule 5.1. Constitutional Challenge to a Statute"
+title: Rule 5.1. Constitutional Challenge to a Statute
 permalink: /frcp/rule_5.1/
 order: 5.1
+chapter: Title II. Commencing an Action; Service of Process, Pleadings, Motions, and
+  Orders
 ---
 
 (a) Notice by a Party. A party that files a pleading, written motion, or other paper drawing into question the constitutionality of a federal or state statute must promptly:

--- a/_frcp/rule_5.2.md
+++ b/_frcp/rule_5.2.md
@@ -1,8 +1,10 @@
 ---
 layout: rule
-title: "Rule 5.2. Privacy Protection For Filings Made with the Court"
+title: Rule 5.2. Privacy Protection For Filings Made with the Court
 permalink: /frcp/rule_5.2/
 order: 5.2
+chapter: Title II. Commencing an Action; Service of Process, Pleadings, Motions, and
+  Orders
 ---
 
 (a) Redacted Filings. Unless the court orders otherwise, in an electronic or paper filing with the court that contains an individual's social-security number, taxpayer-identification number, or birth date, the name of an individual known to be a minor, or a financial-account number, a party or nonparty making the filing may include only:

--- a/_frcp/rule_5.md
+++ b/_frcp/rule_5.md
@@ -1,8 +1,10 @@
 ---
 layout: rule
-title: "Rule 5. Serving and Filing Pleadings and Other Papers"
+title: Rule 5. Serving and Filing Pleadings and Other Papers
 permalink: /frcp/rule_5/
 order: 5
+chapter: Title II. Commencing an Action; Service of Process, Pleadings, Motions, and
+  Orders
 ---
 
 (a) Service: When Required.

--- a/_frcp/rule_50.md
+++ b/_frcp/rule_50.md
@@ -1,8 +1,10 @@
 ---
 layout: rule
-title: "Rule 50. Judgment as a Matter of Law in a Jury Trial; Related Motion for a New Trial; Conditional Ruling"
+title: Rule 50. Judgment as a Matter of Law in a Jury Trial; Related Motion for a
+  New Trial; Conditional Ruling
 permalink: /frcp/rule_50/
 order: 50
+chapter: Title VI. Trials
 ---
 
 (a) Judgment as a Matter of Law.

--- a/_frcp/rule_51.md
+++ b/_frcp/rule_51.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 51. Instructions to the Jury; Objections; Preserving a Claim of Error"
+title: Rule 51. Instructions to the Jury; Objections; Preserving a Claim of Error
 permalink: /frcp/rule_51/
 order: 51
+chapter: Title VI. Trials
 ---
 
 (a) Requests.

--- a/_frcp/rule_52.md
+++ b/_frcp/rule_52.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 52. Findings and Conclusions by the Court; Judgment on Partial Findings"
+title: Rule 52. Findings and Conclusions by the Court; Judgment on Partial Findings
 permalink: /frcp/rule_52/
 order: 52
+chapter: Title VI. Trials
 ---
 
 (a) Findings and Conclusions.

--- a/_frcp/rule_53.md
+++ b/_frcp/rule_53.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 53. Masters"
+title: Rule 53. Masters
 permalink: /frcp/rule_53/
 order: 53
+chapter: Title VI. Trials
 ---
 
 (a) Appointment.

--- a/_frcp/rule_57.md
+++ b/_frcp/rule_57.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 57. Declaratory Judgment"
+title: Rule 57. Declaratory Judgment
 permalink: /frcp/rule_57/
 order: 57
+chapter: Title VII. Judgment
 ---
 
 These rules govern the procedure for obtaining a declaratory judgment under 28 U.S.C. §2201 . Rules 38 and 39 govern a demand for a jury trial. The existence of another adequate remedy does not preclude a declaratory judgment that is otherwise appropriate. The court may order a speedy hearing of a declaratory-judgment action.

--- a/_frcp/rule_58.md
+++ b/_frcp/rule_58.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 58. Entering Judgment"
+title: Rule 58. Entering Judgment
 permalink: /frcp/rule_58/
 order: 58
+chapter: Title VII. Judgment
 ---
 
 (a) Separate Document. Every judgment and amended judgment must be set out in a separate document, but a separate document is not required for an order disposing of a motion:

--- a/_frcp/rule_59.md
+++ b/_frcp/rule_59.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 59. New Trial; Altering or Amending a Judgment"
+title: Rule 59. New Trial; Altering or Amending a Judgment
 permalink: /frcp/rule_59/
 order: 59
+chapter: Title VII. Judgment
 ---
 
 (a) In General.

--- a/_frcp/rule_6.md
+++ b/_frcp/rule_6.md
@@ -1,8 +1,10 @@
 ---
 layout: rule
-title: "Rule 6. Computing and Extending Time; Time for Motion Papers"
+title: Rule 6. Computing and Extending Time; Time for Motion Papers
 permalink: /frcp/rule_6/
 order: 6
+chapter: Title II. Commencing an Action; Service of Process, Pleadings, Motions, and
+  Orders
 ---
 
 (a) Computing Time. The following rules apply in computing any time period specified in these rules, in any local rule or court order, or in any statute that does not specify a method of computing time.

--- a/_frcp/rule_60.md
+++ b/_frcp/rule_60.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 60. Relief from a Judgment or Order"
+title: Rule 60. Relief from a Judgment or Order
 permalink: /frcp/rule_60/
 order: 60
+chapter: Title VII. Judgment
 ---
 
 (a) Corrections Based on Clerical Mistakes; Oversights and Omissions. The court may correct a clerical mistake or a mistake arising from oversight or omission whenever one is found in a judgment, order, or other part of the record. The court may do so on motion or on its own, with or without notice. But after an appeal has been docketed in the appellate court and while it is pending, such a mistake may be corrected only with the appellate court's leave.

--- a/_frcp/rule_61.md
+++ b/_frcp/rule_61.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 61. Harmless Error"
+title: Rule 61. Harmless Error
 permalink: /frcp/rule_61/
 order: 61
+chapter: Title VII. Judgment
 ---
 
 Unless justice requires otherwise, no error in admitting or excluding evidence—or any other error by the court or a party—is ground for granting a new trial, for setting aside a verdict, or for vacating, modifying, or otherwise disturbing a judgment or order. At every stage of the proceeding, the court must disregard all errors and defects that do not affect any party's substantial rights.

--- a/_frcp/rule_62.1.md
+++ b/_frcp/rule_62.1.md
@@ -1,8 +1,10 @@
 ---
 layout: rule
-title: "Rule 62.1. Indicative Ruling on a Motion for Relief That is Barred by a Pending Appeal"
+title: Rule 62.1. Indicative Ruling on a Motion for Relief That is Barred by a Pending
+  Appeal
 permalink: /frcp/rule_62.1/
 order: 62.1
+chapter: Title VII. Judgment
 ---
 
 (a) Relief Pending Appeal. If a timely motion is made for relief that the court lacks authority to grant because of an appeal that has been docketed and is pending, the court may:

--- a/_frcp/rule_62.md
+++ b/_frcp/rule_62.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 62. Stay of Proceedings to Enforce a Judgment"
+title: Rule 62. Stay of Proceedings to Enforce a Judgment
 permalink: /frcp/rule_62/
 order: 62
+chapter: Title VII. Judgment
 ---
 
 (a) Automatic Stay. Except as provided in Rule 62(c) and (d), execution on a judgment and proceedings to enforce it are stayed for 30 days after its entry, unless the court orders otherwise.

--- a/_frcp/rule_63.md
+++ b/_frcp/rule_63.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 63. Judge's Inability to Proceed"
+title: Rule 63. Judge's Inability to Proceed
 permalink: /frcp/rule_63/
 order: 63
+chapter: Title VII. Judgment
 ---
 
 If a judge conducting a hearing or trial is unable to proceed, any other judge may proceed upon certifying familiarity with the record and determining that the case may be completed without prejudice to the parties. In a hearing or a nonjury trial, the successor judge must, at a party's request, recall any witness whose testimony is material and disputed and who is available to testify again without undue burden. The successor judge may also recall any other witness.

--- a/_frcp/rule_64.md
+++ b/_frcp/rule_64.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 64. Seizing a Person or Property"
+title: Rule 64. Seizing a Person or Property
 permalink: /frcp/rule_64/
 order: 64
+chapter: Title VIII. Provisional and Final Remedies
 ---
 
 (a) Remedies Under State Law—In General. At the commencement of and throughout an action, every remedy is available that, under the law of the state where the court is located, provides for seizing a person or property to secure satisfaction of the potential judgment. But a federal statute governs to the extent it applies.

--- a/_frcp/rule_65.1.md
+++ b/_frcp/rule_65.1.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 65.1. Proceedings Against a Security Provider"
+title: Rule 65.1. Proceedings Against a Security Provider
 permalink: /frcp/rule_65.1/
 order: 65.1
+chapter: Title VIII. Provisional and Final Remedies
 ---
 
 Whenever these rules (including the Supplemental Rules for Admiralty or Maritime Claims and Asset Forfeiture Actions ) require or allow a party to give security, and security is given with one or more security providers, each provider submits to the court's jurisdiction and irrevocably appoints the court clerk as its agent for receiving service of any papers that affect its liability on the security. The security provider's liability may be enforced on motion without an independent action. The motion and any notice that the court orders may be served on the court clerk, who must promptly send a copy of each to every security provider whose address is known

--- a/_frcp/rule_65.md
+++ b/_frcp/rule_65.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 65. Injunctions and Restraining Orders"
+title: Rule 65. Injunctions and Restraining Orders
 permalink: /frcp/rule_65/
 order: 65
+chapter: Title VIII. Provisional and Final Remedies
 ---
 
 (a) Preliminary Injunction.

--- a/_frcp/rule_66.md
+++ b/_frcp/rule_66.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 66. Receivers"
+title: Rule 66. Receivers
 permalink: /frcp/rule_66/
 order: 66
+chapter: Title VIII. Provisional and Final Remedies
 ---
 
 These rules govern an action in which the appointment of a receiver is sought or a receiver sues or is sued. But the practice in administering an estate by a receiver or a similar court-appointed officer must accord with the historical practice in federal courts or with a local rule. An action in which a receiver has been appointed may be dismissed only by court order.

--- a/_frcp/rule_67.md
+++ b/_frcp/rule_67.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 67. Deposit into Court"
+title: Rule 67. Deposit into Court
 permalink: /frcp/rule_67/
 order: 67
+chapter: Title VIII. Provisional and Final Remedies
 ---
 
 (a) Depositing Property. If any part of the relief sought is a money judgment or the disposition of a sum of money or some other deliverable thing, a party—on notice to every other party and by leave of court—may deposit with the court all or part of the money or thing, whether or not that party claims any of it. The depositing party must deliver to the clerk a copy of the order permitting deposit.

--- a/_frcp/rule_68.md
+++ b/_frcp/rule_68.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 68. Offer of Judgment"
+title: Rule 68. Offer of Judgment
 permalink: /frcp/rule_68/
 order: 68
+chapter: Title VIII. Provisional and Final Remedies
 ---
 
 (a) Making an Offer; Judgment on an Accepted Offer. At least 14 days before the date set for trial, a party defending against a claim may serve on an opposing party an offer to allow judgment on specified terms, with the costs then accrued. If, within 14 days after being served, the opposing party serves written notice accepting the offer, either party may then file the offer and notice of acceptance, plus proof of service. The clerk must then enter judgment.

--- a/_frcp/rule_69.md
+++ b/_frcp/rule_69.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 69. Execution"
+title: Rule 69. Execution
 permalink: /frcp/rule_69/
 order: 69
+chapter: Title VIII. Provisional and Final Remedies
 ---
 
 (a) In General.

--- a/_frcp/rule_7.1.md
+++ b/_frcp/rule_7.1.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 7.1. Disclosure Statement"
+title: Rule 7.1. Disclosure Statement
 permalink: /frcp/rule_7.1/
 order: 7.1
+chapter: Title III. Pleadings and Motions
 ---
 
 (a) Who Must File; Contents.

--- a/_frcp/rule_7.md
+++ b/_frcp/rule_7.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 7. Pleadings Allowed; Form of Motions and Other Papers"
+title: Rule 7. Pleadings Allowed; Form of Motions and Other Papers
 permalink: /frcp/rule_7/
 order: 7
+chapter: Title III. Pleadings and Motions
 ---
 
 (a) Pleadings. Only these pleadings are allowed:

--- a/_frcp/rule_70.md
+++ b/_frcp/rule_70.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 70. Enforcing a Judgment for a Specific Act"
+title: Rule 70. Enforcing a Judgment for a Specific Act
 permalink: /frcp/rule_70/
 order: 70
+chapter: Title VIII. Provisional and Final Remedies
 ---
 
 (a) Party's Failure to Act; Ordering Another to Act. If a judgment requires a party to convey land, to deliver a deed or other document, or to perform any other specific act and the party fails to comply within the time specified, the court may order the act to be done—at the disobedient party's expense—by another person appointed by the court. When done, the act has the same effect as if done by the party.

--- a/_frcp/rule_71.md
+++ b/_frcp/rule_71.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 71. Enforcing Relief For or Against a Nonparty"
+title: Rule 71. Enforcing Relief For or Against a Nonparty
 permalink: /frcp/rule_71/
 order: 71
+chapter: Title VIII. Provisional and Final Remedies
 ---
 
 When an order grants relief for a nonparty or may be enforced against a nonparty, the procedure for enforcing the order is the same as for a party.

--- a/_frcp/rule_72.md
+++ b/_frcp/rule_72.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 72. Magistrate Judges: Pretrial Order"
+title: 'Rule 72. Magistrate Judges: Pretrial Order'
 permalink: /frcp/rule_72/
 order: 72
+chapter: Title IX. Special Proceedings
 ---
 
 (a) Nondispositive Matters. When a pretrial matter not dispositive of a party's claim or defense is referred to a magistrate judge to hear and decide, the magistrate judge must promptly conduct the required proceedings and, when appropriate, issue a written order stating the decision. A party may serve and file objections to the order within 14 days after being served with a copy. A party may not assign as error a defect in the order not timely objected to. The district judge in the case must consider timely objections and modify or set aside any part of the order that is clearly erroneous or is contrary to law.

--- a/_frcp/rule_73.md
+++ b/_frcp/rule_73.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 73. Magistrate Judges: Trial by Consent; Appeal"
+title: 'Rule 73. Magistrate Judges: Trial by Consent; Appeal'
 permalink: /frcp/rule_73/
 order: 73
+chapter: Title IX. Special Proceedings
 ---
 
 (a) Trial by Consent. When authorized under 28 U.S.C. §636(c) , a magistrate judge may, if all parties consent, conduct a civil action or proceeding, including a jury or nonjury trial. A record must be made in accordance with 28 U.S.C. §636(c)(5) .

--- a/_frcp/rule_78.md
+++ b/_frcp/rule_78.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 78. Hearing Motions; Submission on Briefs"
+title: Rule 78. Hearing Motions; Submission on Briefs
 permalink: /frcp/rule_78/
 order: 78
+chapter: Title X. District Courts and Clerks
 ---
 
 (a) Providing a Regular Schedule for Oral Hearings. A court may establish regular times and places for oral hearings on motions.

--- a/_frcp/rule_79.md
+++ b/_frcp/rule_79.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 79. Records Kept by the Clerk"
+title: Rule 79. Records Kept by the Clerk
 permalink: /frcp/rule_79/
 order: 79
+chapter: Title X. District Courts and Clerks
 ---
 
 (a) Civil Docket.

--- a/_frcp/rule_8.md
+++ b/_frcp/rule_8.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 8. General Rules of Pleading"
+title: Rule 8. General Rules of Pleading
 permalink: /frcp/rule_8/
 order: 8
+chapter: Title III. Pleadings and Motions
 ---
 
 (a) Claim for Relief. A pleading that states a claim for relief must contain:

--- a/_frcp/rule_80.md
+++ b/_frcp/rule_80.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 80. Stenographic Transcript as Evidence"
+title: Rule 80. Stenographic Transcript as Evidence
 permalink: /frcp/rule_80/
 order: 80
+chapter: Title X. District Courts and Clerks
 ---
 
 If stenographically reported testimony at a hearing or trial is admissible in evidence at a later trial, the testimony may be proved by a transcript certified by the person who reported it.

--- a/_frcp/rule_81.md
+++ b/_frcp/rule_81.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 81. Applicability of the Rules in General; Removed Actions"
+title: Rule 81. Applicability of the Rules in General; Removed Actions
 permalink: /frcp/rule_81/
 order: 81
+chapter: Title XI. General Provisions
 ---
 
 (a) Applicability to Particular Proceedings.

--- a/_frcp/rule_82.md
+++ b/_frcp/rule_82.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 82. Jurisdiction and Venue Unaffected"
+title: Rule 82. Jurisdiction and Venue Unaffected
 permalink: /frcp/rule_82/
 order: 82
+chapter: Title XI. General Provisions
 ---
 
 These rules do not extend or limit the jurisdiction of the district courts or the venue of actions in those courts. An admiralty or maritime claim under Rule 9(h) is governed by 28 U.S.C § 1390 .

--- a/_frcp/rule_83.md
+++ b/_frcp/rule_83.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 83. Rules by District Courts; Judge's Directives"
+title: Rule 83. Rules by District Courts; Judge's Directives
 permalink: /frcp/rule_83/
 order: 83
+chapter: Title XI. General Provisions
 ---
 
 (a) Local Rules.

--- a/_frcp/rule_85.md
+++ b/_frcp/rule_85.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 85. Title"
+title: Rule 85. Title
 permalink: /frcp/rule_85/
 order: 85
+chapter: Title XI. General Provisions
 ---
 
 These rules may be cited as the Federal Rules of Civil Procedure .

--- a/_frcp/rule_86.md
+++ b/_frcp/rule_86.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 86. Effective Dates"
+title: Rule 86. Effective Dates
 permalink: /frcp/rule_86/
 order: 86
+chapter: Title XI. General Provisions
 ---
 
 (a) In General. These rules and any amendments take effect at the time specified by the Supreme Court, subject to 28 U.S.C. §2074 . They govern:

--- a/_frcp/rule_87.md
+++ b/_frcp/rule_87.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 87. Civil Rules Emergency"
+title: Rule 87. Civil Rules Emergency
 permalink: /frcp/rule_87/
 order: 87
+chapter: Title XI. General Provisions
 ---
 
 (a) Conditions for an Emergency. The Judicial Conference of the United States may declare a Civil Rules emergency if it determines that extraordinary circumstances relating to public health or safety, or affecting physical or electronic access to a court, substantially impair the court's ability to perform its functions in compliance with these rules.

--- a/_frcp/rule_88.md
+++ b/_frcp/rule_88.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 88. Archival of Voice Proceedings"
+title: Rule 88. Archival of Voice Proceedings
 permalink: /frcp/rule_88/
 order: 88
+chapter: Title XI. General Provisions
 ---
 
 No court shall conduct any part of a judicial proceeding via voice chat unless the following conditions are met:

--- a/_frcp/rule_89.md
+++ b/_frcp/rule_89.md
@@ -1,10 +1,12 @@
 ---
 layout: rule
-title: "Rule 89. Absentia Rule"
+title: Rule 89. Absentia Rule
 permalink: /frcp/rule_89/
 order: 89
 notes:
-    - "[Created](https://trello.com/c/Qu2FRCqc/56-absentia-rule-pursuant-to-28-usc-2072) prior to June 1st, 2025."
+- '[Created](https://trello.com/c/Qu2FRCqc/56-absentia-rule-pursuant-to-28-usc-2072)
+  prior to June 1st, 2025.'
+chapter: Title XI. General Provisions
 ---
 
 (1) This rule shall be effective immediately after passage, shall not expire, and shall apply to all federal courts of the United States.

--- a/_frcp/rule_9.md
+++ b/_frcp/rule_9.md
@@ -1,8 +1,9 @@
 ---
 layout: rule
-title: "Rule 9. Pleading Special Matters"
+title: Rule 9. Pleading Special Matters
 permalink: /frcp/rule_9/
 order: 9
+chapter: Title III. Pleadings and Motions
 ---
 
 (a) Capacity or Authority to Sue; Legal Existence.

--- a/_frcp/rule_90.md
+++ b/_frcp/rule_90.md
@@ -1,10 +1,12 @@
 ---
 layout: rule
-title: "Rule 90. Suspension of Rules"
+title: Rule 90. Suspension of Rules
 permalink: /frcp/rule_90/
 order: 90
 notes:
-    - "[Created](https://trello.com/c/6zOKJEPj/44-creation-of-rule-87-frcp) prior to June 1st, 2025."
+- '[Created](https://trello.com/c/6zOKJEPj/44-creation-of-rule-87-frcp) prior to June
+  1st, 2025.'
+chapter: Title XI. General Provisions
 ---
 
 Any judge shall have the ability to suspend any part of the Rules of Procedure upon notice to all parties involved and upon public publication of the reason of incompatibility with ROBLOX. The Supreme Court shall retain the right to limit or enhance discretion to the issue.

--- a/frap.html
+++ b/frap.html
@@ -8,11 +8,23 @@ breadcrumb_parent_url: /
 ---
 <div class="resource-grid">
   <div class="resource-column">
-    <ul>
-      {% assign rules = site.frap | sort: 'order' %}
-      {% for rule in rules %}
-        <li><a href="{{ site.baseurl }}{{ rule.url }}">{{ rule.title }}</a></li>
+    {% assign rules = site.frap | sort: 'order' %}
+    {% if rules[0].chapter %}
+      {% assign groups = rules | group_by: 'chapter' %}
+      {% for group in groups %}
+        <h2>{{ group.name }}</h2>
+        <ul>
+          {% for rule in group.items %}
+            <li><a href="{{ site.baseurl }}{{ rule.url }}">{{ rule.title }}</a></li>
+          {% endfor %}
+        </ul>
       {% endfor %}
-    </ul>
+    {% else %}
+      <ul>
+        {% for rule in rules %}
+          <li><a href="{{ site.baseurl }}{{ rule.url }}">{{ rule.title }}</a></li>
+        {% endfor %}
+      </ul>
+    {% endif %}
   </div>
 </div>

--- a/frcmp.html
+++ b/frcmp.html
@@ -8,11 +8,23 @@ breadcrumb_parent_url: /
 ---
 <div class="resource-grid">
   <div class="resource-column">
-    <ul>
-      {% assign rules = site.frcmp | sort: 'order' %}
-      {% for rule in rules %}
-        <li><a href="{{ site.baseurl }}{{ rule.url }}">{{ rule.title }}</a></li>
+    {% assign rules = site.frcmp | sort: 'order' %}
+    {% if rules[0].chapter %}
+      {% assign groups = rules | group_by: 'chapter' %}
+      {% for group in groups %}
+        <h2>{{ group.name }}</h2>
+        <ul>
+          {% for rule in group.items %}
+            <li><a href="{{ site.baseurl }}{{ rule.url }}">{{ rule.title }}</a></li>
+          {% endfor %}
+        </ul>
       {% endfor %}
-    </ul>
+    {% else %}
+      <ul>
+        {% for rule in rules %}
+          <li><a href="{{ site.baseurl }}{{ rule.url }}">{{ rule.title }}</a></li>
+        {% endfor %}
+      </ul>
+    {% endif %}
   </div>
 </div>

--- a/frcp.html
+++ b/frcp.html
@@ -8,11 +8,23 @@ breadcrumb_parent_url: /
 ---
 <div class="resource-grid">
   <div class="resource-column">
-    <ul>
-      {% assign rules = site.frcp | sort: 'order' %}
-      {% for rule in rules %}
-        <li><a href="{{ site.baseurl }}{{ rule.url }}">{{ rule.title }}</a></li>
+    {% assign rules = site.frcp | sort: 'order' %}
+    {% if rules[0].chapter %}
+      {% assign groups = rules | group_by: 'chapter' %}
+      {% for group in groups %}
+        <h2>{{ group.name }}</h2>
+        <ul>
+          {% for rule in group.items %}
+            <li><a href="{{ site.baseurl }}{{ rule.url }}">{{ rule.title }}</a></li>
+          {% endfor %}
+        </ul>
       {% endfor %}
-    </ul>
+    {% else %}
+      <ul>
+        {% for rule in rules %}
+          <li><a href="{{ site.baseurl }}{{ rule.url }}">{{ rule.title }}</a></li>
+        {% endfor %}
+      </ul>
+    {% endif %}
   </div>
 </div>

--- a/fre.html
+++ b/fre.html
@@ -8,11 +8,23 @@ breadcrumb_parent_url: /
 ---
 <div class="resource-grid">
   <div class="resource-column">
-    <ul>
-      {% assign rules = site.fre | sort: 'order' %}
-      {% for rule in rules %}
-        <li><a href="{{ site.baseurl }}{{ rule.url }}">{{ rule.title }}</a></li>
+    {% assign rules = site.fre | sort: 'order' %}
+    {% if rules[0].chapter %}
+      {% assign groups = rules | group_by: 'chapter' %}
+      {% for group in groups %}
+        <h2>{{ group.name }}</h2>
+        <ul>
+          {% for rule in group.items %}
+            <li><a href="{{ site.baseurl }}{{ rule.url }}">{{ rule.title }}</a></li>
+          {% endfor %}
+        </ul>
       {% endfor %}
-    </ul>
+    {% else %}
+      <ul>
+        {% for rule in rules %}
+          <li><a href="{{ site.baseurl }}{{ rule.url }}">{{ rule.title }}</a></li>
+        {% endfor %}
+      </ul>
+    {% endif %}
   </div>
 </div>

--- a/supct.html
+++ b/supct.html
@@ -8,11 +8,23 @@ breadcrumb_parent_url: /
 ---
 <div class="resource-grid">
   <div class="resource-column">
-    <ul>
-      {% assign rules = site.supct | sort: 'order' %}
-      {% for rule in rules %}
-        <li><a href="{{ site.baseurl }}{{ rule.url }}">{{ rule.title }}</a></li>
+    {% assign rules = site.supct | sort: 'order' %}
+    {% if rules[0].chapter %}
+      {% assign groups = rules | group_by: 'chapter' %}
+      {% for group in groups %}
+        <h2>{{ group.name }}</h2>
+        <ul>
+          {% for rule in group.items %}
+            <li><a href="{{ site.baseurl }}{{ rule.url }}">{{ rule.title }}</a></li>
+          {% endfor %}
+        </ul>
       {% endfor %}
-    </ul>
+    {% else %}
+      <ul>
+        {% for rule in rules %}
+          <li><a href="{{ site.baseurl }}{{ rule.url }}">{{ rule.title }}</a></li>
+        {% endfor %}
+      </ul>
+    {% endif %}
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Add `chapter` front matter to all Federal Rules of Civil Procedure files to enable grouped listings.
- Update rule listing pages to partition collections by chapter metadata and render `<h2>` headings for each group.

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d4ebb9f48326abdbbaecc41ee9fd