### PR TITLE
Add dynamic TOC to rule pages

### DIFF
--- a/_layouts/rule.html
+++ b/_layouts/rule.html
@@ -29,6 +29,7 @@
 
     <main id="top" class="content-container">
         <h1>{{ page.title }}</h1>
+        <nav id="toc" class="rule-toc"></nav>
         {{ content }}
 
         {% if page.notes %}
@@ -48,6 +49,30 @@
     </main>
 
     {% include footer.html %}
+
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const toc = document.getElementById('toc');
+        const content = document.querySelector('main');
+        if (!toc || !content) return;
+        const headings = Array.from(content.querySelectorAll('h2, h3')).filter(h => !h.closest('.rule-notes'));
+        if (!headings.length) return;
+        const list = document.createElement('ul');
+        headings.forEach(h => {
+            if (!h.id) {
+                h.id = h.textContent.trim().toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9\-]/g, '');
+            }
+            const li = document.createElement('li');
+            if (h.tagName.toLowerCase() === 'h3') li.classList.add('toc-sub');
+            const a = document.createElement('a');
+            a.href = '#' + h.id;
+            a.textContent = h.textContent;
+            li.appendChild(a);
+            list.appendChild(li);
+        });
+        toc.appendChild(list);
+    });
+    </script>
 </body>
 
 </html>

--- a/assets/style.css
+++ b/assets/style.css
@@ -818,3 +818,30 @@ html {
 .rules-list-container .resource-column {
   max-width: none;
 }
+
+/* Rule page table of contents */
+.rule-toc {
+  border: 1px solid #ccc;
+  background: #f9f9f9;
+  padding: 1rem;
+  margin: 1rem 0;
+}
+.rule-toc ul {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+}
+.rule-toc li {
+  margin-bottom: 0.25rem;
+}
+.rule-toc li.toc-sub {
+  margin-left: 1rem;
+  font-size: 0.95em;
+}
+.rule-toc a {
+  text-decoration: none;
+  color: #003366;
+}
+.rule-toc a:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
## Summary
- inject TOC container and client-side script to build links for h2/h3 subsections
- add styling for rule page table of contents

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68c6d4efa8448326a645ef582dc704a9