### PR TITLE
Highlight active navigation links

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -19,12 +19,12 @@
     <div id="cornell-nav-bg">
         <nav class="header-container" id="cornell-nav">
             <ul>
-                <li><a href="{{ site.baseurl }}/frap/">Appellate Procedure</a></li>
-                <li><a href="{{ site.baseurl }}/frcp/">Civil Procedure</a></li>
-                <li><a href="{{ site.baseurl }}/frcmp/">Criminal Procedure</a></li>
-                <li><a href="{{ site.baseurl }}/fre/">Rules of Evidence</a></li>
-                <li><a href="{{ site.baseurl }}/supct/">Supreme Court Rules</a></li>
-                <li><a href="{{ site.baseurl }}/docs/">Document Library</a></li>
+                <li{% if page.url contains '/frap/' %} class="active"{% endif %}><a href="{{ site.baseurl }}/frap/">Appellate Procedure</a></li>
+                <li{% if page.url contains '/frcp/' %} class="active"{% endif %}><a href="{{ site.baseurl }}/frcp/">Civil Procedure</a></li>
+                <li{% if page.url contains '/frcmp/' %} class="active"{% endif %}><a href="{{ site.baseurl }}/frcmp/">Criminal Procedure</a></li>
+                <li{% if page.url contains '/fre/' %} class="active"{% endif %}><a href="{{ site.baseurl }}/fre/">Rules of Evidence</a></li>
+                <li{% if page.url contains '/supct/' %} class="active"{% endif %}><a href="{{ site.baseurl }}/supct/">Supreme Court Rules</a></li>
+                <li{% if page.url contains '/docs/' %} class="active"{% endif %}><a href="{{ site.baseurl }}/docs/">Document Library</a></li>
             </ul>
         </nav>
     </div>

--- a/assets/style.css
+++ b/assets/style.css
@@ -309,7 +309,8 @@ body::before {
   transition: all 0.2s ease-in-out;
 }
 
-#cornell-nav a:hover {
+#cornell-nav a:hover,
+#cornell-nav li.active > a {
   color: #1e40af;
   background: rgba(30, 64, 175, 0.07);
 }


### PR DESCRIPTION
## Summary
- Add conditional `active` class to nav items when their link matches `page.url`
- Style `.active` list items so current section is highlighted in navigation

## Testing
- `jekyll build`
- `grep -n '<li class="active"' -n _site/frcp/rule_1/index.html`


------
https://chatgpt.com/codex/tasks/task_e_68c6d4f0fca48326853d90f13b1808ed