### PR TITLE
Add Trello docket fallback

### DIFF
--- a/.github/workflows/update-fallback.yml
+++ b/.github/workflows/update-fallback.yml
@@ -1,0 +1,25 @@
+name: Update docket fallback
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: node scripts/update-fallback.js
+        env:
+          TRELLO_KEY: ${{ secrets.TRELLO_KEY }}
+          TRELLO_TOKEN: ${{ secrets.TRELLO_TOKEN }}
+      - run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add assets/docket-fallback.json
+          git commit -m "chore: update docket fallback" || echo "No changes to commit"
+          git push

--- a/assets/docket-fallback.json
+++ b/assets/docket-fallback.json
@@ -1,0 +1,4 @@
+{
+  "MMA90mFH": [],
+  "rbISqlOt": []
+}

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@ show_breadcrumbs: false
         <div id="docket-cards-supreme" class="docket-scroll">
           <!-- Supreme Court cards will load here -->
         </div>
-        <p id="docket-error-supreme" class="docket-error hidden">Unable to load the docket. Please try again later.</p>
+        <p id="docket-error-supreme" class="docket-error hidden">Unable to load docket data. Please try again later.</p>
       </div>
 
       <!-- District Court Column -->
@@ -32,7 +32,7 @@ show_breadcrumbs: false
         <div id="docket-cards-district" class="docket-scroll">
           <!-- District Court cards will load here -->
         </div>
-        <p id="docket-error-district" class="docket-error hidden">Unable to load the docket. Please try again later.</p>
+        <p id="docket-error-district" class="docket-error hidden">Unable to load docket data. Please try again later.</p>
       </div>
 
     </div>
@@ -194,9 +194,10 @@ show_breadcrumbs: false
 
       const abortTimer = setTimeout(() => controller.abort(), 8000);
 
-      const handleError = (err) => {
-        console.error(`Failed to load ${errorId}:`, err);
+      const showError = () => {
+        container.innerHTML = "";
         if (errorEl) {
+          errorEl.textContent = "Unable to load docket data.";
           errorEl.classList.remove("hidden");
           if (!errorEl.querySelector("button")) {
             const retryBtn = document.createElement("button");
@@ -212,6 +213,20 @@ show_breadcrumbs: false
         }
       };
 
+      const loadFallback = () => {
+        fetch("assets/docket-fallback.json")
+          .then(res => res.json())
+          .then(data => {
+            const cards = data[boardId] || [];
+            if (cards.length > 0) {
+              renderList(container, cards);
+            } else {
+              showError();
+            }
+          })
+          .catch(showError);
+      };
+
       fetch(`https://api.trello.com/1/boards/${boardId}/lists?cards=open&card_fields=name,desc,url,labels&fields=name`, { signal: controller.signal })
         .then(res => res.json())
         .then(lists => {
@@ -220,10 +235,10 @@ show_breadcrumbs: false
           if (cards.length > 0) {
             renderList(container, cards);
           } else {
-            handleError(new Error("No cards"));
+            loadFallback();
           }
         })
-        .catch(handleError)
+        .catch(loadFallback)
         .finally(() => {
           clearTimeout(slowTimer);
           clearTimeout(abortTimer);

--- a/scripts/update-fallback.js
+++ b/scripts/update-fallback.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+
+const boards = ['MMA90mFH', 'rbISqlOt'];
+const key = process.env.TRELLO_KEY;
+const token = process.env.TRELLO_TOKEN;
+
+if (!key || !token) {
+  console.error('Missing Trello credentials');
+  process.exit(1);
+}
+
+async function fetchBoard(boardId) {
+  const url = `https://api.trello.com/1/boards/${boardId}/lists?cards=open&card_fields=name,desc,url,labels&fields=name&key=${key}&token=${token}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch board ${boardId}`);
+  }
+  return res.json();
+}
+
+async function main() {
+  const data = {};
+  for (const boardId of boards) {
+    const lists = await fetchBoard(boardId);
+    const matchingLists = lists.filter(list => list.name.toLowerCase().includes('docket'));
+    const cards = matchingLists.flatMap(list => list.cards || []);
+    data[boardId] = cards;
+  }
+  fs.writeFileSync('assets/docket-fallback.json', JSON.stringify(data, null, 2));
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Load cached `assets/docket-fallback.json` when Trello fetch fails and show error if no data available
- Add script to pull Trello data and save it as fallback JSON
- Schedule workflow to periodically update fallback file from Trello

## Testing
- `node scripts/update-fallback.js` *(fails: Missing Trello credentials)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d5019a2483268e531f3cd69ccce8