### PR TITLE
Add about and disclaimer pages with site notice

### DIFF
--- a/_includes/disclaimer.html
+++ b/_includes/disclaimer.html
@@ -1,0 +1,3 @@
+<div class="disclaimer-banner">
+  <p><strong>Disclaimer:</strong> This site provides general legal information and does not constitute legal advice.</p>
+</div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,6 +7,8 @@
             <a href="https://discord.gg/fknPvcCfFp">ULPA Server</a>
             <a href="https://www.law.cornell.edu/">Cornell Law</a>
             <a href="{{ site.baseurl }}/help/">Help</a>
+            <a href="{{ site.baseurl }}/about/">About</a>
+            <a href="{{ site.baseurl }}/disclaimer/">Disclaimer</a>
         </div>
 
         <hr class="footer-divider" />

--- a/_layouts/rule.html
+++ b/_layouts/rule.html
@@ -28,6 +28,7 @@
 
 
     <main id="top" class="content-container">
+        {% include disclaimer.html %}
         <h1>{{ page.title }}</h1>
         {{ content }}
 

--- a/about.html
+++ b/about.html
@@ -1,0 +1,15 @@
+---
+layout: page
+title: About
+permalink: /about/
+show_breadcrumbs: true
+breadcrumb_parent: "Legal Directory"
+breadcrumb_parent_url: /
+---
+
+<section class="about-section">
+  <h1>About the Legal Directory</h1>
+  <p>The Legal Directory centralizes federal rules and court procedures to help the community quickly locate authoritative sources.</p>
+  <p>This project is maintained by RaymondLWeston, JaredLPaguio, and the United States Supreme Court of USAR.</p>
+  <p><strong>Disclaimer:</strong> The information provided on this site is for informational purposes only and does not constitute legal advice.</p>
+</section>

--- a/disclaimer.html
+++ b/disclaimer.html
@@ -1,0 +1,15 @@
+---
+layout: page
+title: Disclaimer
+permalink: /disclaimer/
+show_breadcrumbs: true
+breadcrumb_parent: "Legal Directory"
+breadcrumb_parent_url: /
+---
+
+<section class="disclaimer-section">
+  <h1>Disclaimer</h1>
+  <p>The materials on this website are provided for general informational purposes only.</p>
+  <p>They are maintained by RaymondLWeston, JaredLPaguio, and the United States Supreme Court of USAR.</p>
+  <p>No content here should be construed as legal advice. Users should consult a qualified attorney for guidance on legal matters.</p>
+</section>

--- a/help.html
+++ b/help.html
@@ -27,5 +27,8 @@ breadcrumb_parent_url: /
     <li>The breadcrumb trail at the top of the page helps you track your current location within the site.</li>
     <li>Links in the footer provide quick access to related resources and support servers.</li>
   </ul>
+
+  <h2>More Information</h2>
+  <p>Learn more about this project on the <a href="{{ site.baseurl }}/about/">About</a> page or review the <a href="{{ site.baseurl }}/disclaimer/">Disclaimer</a>.</p>
 </section>
 


### PR DESCRIPTION
## Summary
- Add About and Disclaimer pages describing the project's purpose, maintenance team, and legal notice
- Introduce reusable disclaimer partial and surface it on rule pages
- Link new pages from footer and Help page

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68c6d9926f4083269c236e119a2a29f7