### PR TITLE
Add copyable anchor links to rule headings

### DIFF
--- a/_layouts/rule.html
+++ b/_layouts/rule.html
@@ -51,25 +51,51 @@
 
     <script>
     document.addEventListener('DOMContentLoaded', function() {
-        const toc = document.getElementById('toc');
         const content = document.querySelector('main');
-        if (!toc || !content) return;
+        if (!content) return;
+
         const headings = Array.from(content.querySelectorAll('h2, h3')).filter(h => !h.closest('.rule-notes'));
         if (!headings.length) return;
-        const list = document.createElement('ul');
+
+        const toc = document.getElementById('toc');
+        const list = toc ? document.createElement('ul') : null;
+
         headings.forEach(h => {
+            const title = h.textContent.trim();
             if (!h.id) {
-                h.id = h.textContent.trim().toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9\-]/g, '');
+                h.id = title.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9\-]/g, '');
             }
-            const li = document.createElement('li');
-            if (h.tagName.toLowerCase() === 'h3') li.classList.add('toc-sub');
-            const a = document.createElement('a');
-            a.href = '#' + h.id;
-            a.textContent = h.textContent;
-            li.appendChild(a);
-            list.appendChild(li);
+
+            const anchor = document.createElement('a');
+            anchor.href = '#' + h.id;
+            anchor.className = 'heading-anchor';
+            anchor.textContent = '#';
+
+            const copyBtn = document.createElement('button');
+            copyBtn.type = 'button';
+            copyBtn.className = 'copy-anchor';
+            copyBtn.setAttribute('aria-label', 'Copy link');
+            copyBtn.textContent = 'Copy';
+            copyBtn.addEventListener('click', () => {
+                const url = `${window.location.origin}${window.location.pathname}#${h.id}`;
+                navigator.clipboard.writeText(url);
+            });
+
+            h.appendChild(anchor);
+            h.appendChild(copyBtn);
+
+            if (list) {
+                const li = document.createElement('li');
+                if (h.tagName.toLowerCase() === 'h3') li.classList.add('toc-sub');
+                const a = document.createElement('a');
+                a.href = '#' + h.id;
+                a.textContent = title;
+                li.appendChild(a);
+                list.appendChild(li);
+            }
         });
-        toc.appendChild(list);
+
+        if (list) toc.appendChild(list);
     });
     </script>
 </body>

--- a/assets/style.css
+++ b/assets/style.css
@@ -898,3 +898,33 @@ html {
 .rule-toc a:hover {
   text-decoration: underline;
 }
+
+/* Heading anchors and copy buttons */
+h2 .heading-anchor,
+h2 .copy-anchor,
+h3 .heading-anchor,
+h3 .copy-anchor {
+  opacity: 0;
+  margin-left: 0.25rem;
+  font-size: 0.85rem;
+}
+
+.heading-anchor {
+  text-decoration: none;
+}
+
+.copy-anchor {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+h2:hover .heading-anchor,
+h2:hover .copy-anchor,
+h3:hover .heading-anchor,
+h3:hover .copy-anchor,
+.heading-anchor:focus,
+.copy-anchor:focus {
+  opacity: 1;
+}


### PR DESCRIPTION
## Summary
- add script to insert anchor links and copy buttons for rule page headings
- style anchor and copy button to show on hover or focus

## Testing
- `jekyll build` *(fails: command not found)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d9a49a8c83269064fe630d7a98d7