### PR TITLE
Add SCDB topic classification pipeline

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,5 @@
+"""Model package for legal directory."""
+
+from .topic_classifier import TopicClassifier
+
+__all__ = ["TopicClassifier"]

--- a/models/topic_classifier.py
+++ b/models/topic_classifier.py
@@ -1,0 +1,36 @@
+"""Topic classification for Supreme Court Database (SCDB) issues."""
+
+from __future__ import annotations
+
+from typing import List
+
+from transformers import pipeline
+
+SCDB_TOPICS: List[str] = [
+    "Criminal Procedure",
+    "Civil Rights",
+    "First Amendment",
+    "Due Process",
+    "Privacy",
+    "Attorneys",
+    "Unions",
+    "Economic Activity",
+    "Judicial Power",
+    "Federalism",
+    "Interstate Relations",
+    "Federal Taxation",
+    "Miscellaneous",
+    "Unspecified",
+]
+
+
+class TopicClassifier:
+    """Predict the best matching SCDB topic for a piece of text."""
+
+    def __init__(self, model_name: str = "valhalla/distilbart-mnli-12-6") -> None:
+        self._classifier = pipeline("zero-shot-classification", model=model_name)
+
+    def predict(self, text: str) -> str:
+        """Return the highest-scoring SCDB topic for *text*."""
+        result = self._classifier(text, SCDB_TOPICS)
+        return result["labels"][0]

--- a/scripts/classify.py
+++ b/scripts/classify.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Classify opinions into SCDB topics using a transformer model."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from models import TopicClassifier
+
+
+def iter_opinion_files(directory: Path):
+    for path in sorted(directory.glob("*.json")):
+        if path.is_file():
+            yield path
+
+
+def classify_files(directory: Path, classifier: TopicClassifier) -> None:
+    for path in iter_opinion_files(directory):
+        with path.open() as f:
+            data = json.load(f)
+        text = data.get("text") or data.get("content") or ""
+        if not text:
+            continue
+        topic = classifier.predict(text)
+        data["predicted_topic"] = topic
+        with path.open("w") as f:
+            json.dump(data, f, indent=2)
+        print(f"{path.name}: {topic}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        default=Path(__file__).resolve().parents[1] / "data" / "processed",
+        help="Directory containing opinion JSON files",
+    )
+    parser.add_argument(
+        "--model",
+        default="valhalla/distilbart-mnli-12-6",
+        help="Hugging Face model name for zero-shot classification",
+    )
+    args = parser.parse_args()
+
+    classifier = TopicClassifier(args.model)
+    classify_files(args.data_dir, classifier)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add zero-shot SCDB topic classifier using Hugging Face transformers
- provide CLI to classify opinions in `data/processed` and save predictions

## Testing
- `pytest`
- `python scripts/classify.py --data-dir data/processed` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c72f7dd88c8326920b0487e4c57d73