### PR TITLE
Add Elasticsearch indexing tools

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.7'
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.0
+    environment:
+      - discovery.type=single-node
+      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+      - xpack.security.enabled=false
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9200"]
+      interval: 30s
+      timeout: 10s
+      retries: 5

--- a/docs/elasticsearch.md
+++ b/docs/elasticsearch.md
@@ -1,0 +1,25 @@
+# Local Elasticsearch Setup
+
+This project includes a [`docker-compose.yml`](../docker-compose.yml) for running Elasticsearch locally.
+
+## Start Elasticsearch
+
+```bash
+docker-compose up -d elasticsearch
+```
+
+The service exposes the cluster on <http://localhost:9200>.
+
+Verify that Elasticsearch is running:
+
+```bash
+curl http://localhost:9200
+```
+
+## Stop Elasticsearch
+
+When finished, shut down the container:
+
+```bash
+docker-compose down
+```

--- a/scripts/search/index_cases.py
+++ b/scripts/search/index_cases.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Index case JSON files into Elasticsearch."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Iterable
+
+from elasticsearch import Elasticsearch
+
+
+def iter_case_files(directory: Path) -> Iterable[Path]:
+    """Yield JSON files from *directory* in sorted order."""
+    for path in sorted(directory.glob("*.json")):
+        if path.is_file():
+            yield path
+
+
+def load_schema(path: Path) -> dict:
+    """Return JSON schema loaded from *path*."""
+    with path.open() as f:
+        return json.load(f)
+
+
+def index_cases(es: Elasticsearch, index: str, directory: Path) -> None:
+    """Index all case JSON files in *directory* into *index*."""
+    for path in iter_case_files(directory):
+        with path.open() as f:
+            data = json.load(f)
+
+        citation_id = data.get("citation_id") or data.get("id") or data.get("citation")
+        if not citation_id:
+            continue
+
+        topic_codes = data.get("topic_codes") or data.get("topics") or data.get("predicted_topic") or []
+        if isinstance(topic_codes, str):
+            topic_codes = [topic_codes]
+
+        doc = {
+            "citation_id": citation_id,
+            "title": data.get("title"),
+            "text": data.get("text") or data.get("content") or "",
+            "topic_codes": topic_codes,
+            "court": data.get("court"),
+            "date": data.get("date") or data.get("decision_date"),
+        }
+
+        es.index(index=index, id=citation_id, document=doc)
+        print(f"Indexed {citation_id}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--es-url", default="http://localhost:9200", help="Elasticsearch URL")
+    parser.add_argument("--index", default="cases", help="Index name")
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        default=Path(__file__).resolve().parents[2] / "data" / "processed",
+        help="Directory containing case JSON files",
+    )
+    parser.add_argument(
+        "--schema",
+        type=Path,
+        default=Path(__file__).resolve().parents[2] / "search" / "schema.json",
+        help="Path to index schema JSON",
+    )
+    args = parser.parse_args()
+
+    es = Elasticsearch(args.es_url)
+
+    if not es.indices.exists(index=args.index):
+        schema = load_schema(args.schema)
+        es.indices.create(index=args.index, body=schema)
+
+    index_cases(es, args.index, args.data_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/search/schema.json
+++ b/search/schema.json
@@ -1,0 +1,23 @@
+{
+  "settings": {
+    "analysis": {
+      "analyzer": {
+        "legal_text": {
+          "type": "custom",
+          "tokenizer": "standard",
+          "filter": ["lowercase", "stop", "porter_stem"]
+        }
+      }
+    }
+  },
+  "mappings": {
+    "properties": {
+      "citation_id": {"type": "keyword"},
+      "title": {"type": "text", "analyzer": "legal_text"},
+      "text": {"type": "text", "analyzer": "legal_text"},
+      "topic_codes": {"type": "keyword"},
+      "court": {"type": "keyword"},
+      "date": {"type": "date"}
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Define a legal text Elasticsearch schema.
- Add script to index case files with citation IDs and topic codes.
- Provide docker-compose config and documentation for running Elasticsearch locally.

## Testing
- `python -m json.tool search/schema.json`
- `python -m py_compile scripts/search/index_cases.py`
- `docker-compose version` *(fails: No module named 'distutils')*

------
https://chatgpt.com/codex/tasks/task_e_68c731c31a3c83268e53ea0600791db5