### PR TITLE
Add citation schema and ingestion script

### DIFF
--- a/scotus-graph/db/neo4j.cypher
+++ b/scotus-graph/db/neo4j.cypher
@@ -1,0 +1,22 @@
+// Cypher setup for SCOTUS citation graph
+
+// Ensure unique constraint on opinion id
+CREATE CONSTRAINT opinion_id IF NOT EXISTS
+FOR (o:Opinion) REQUIRE o.id IS UNIQUE;
+
+// Load opinions
+// :param opinions_csv => path to courtlistener_opinions.csv
+LOAD CSV WITH HEADERS FROM $opinions_csv AS row
+MERGE (o:Opinion {id: toInteger(row.id)})
+SET o.docket = row.docket,
+    o.case_name = row.case_name,
+    o.date_filed = row.date_filed,
+    o.citation = row.citation,
+    o.absolute_url = row.absolute_url;
+
+// Load citation relationships
+// :param citations_csv => path to courtlistener_citations.csv
+LOAD CSV WITH HEADERS FROM $citations_csv AS row
+MATCH (src:Opinion {id: toInteger(row.source_id)}),
+      (tgt:Opinion {id: toInteger(row.target_id)})
+MERGE (src)-[:CITES]->(tgt);

--- a/scotus-graph/db/schema.sql
+++ b/scotus-graph/db/schema.sql
@@ -1,0 +1,17 @@
+-- SQL schema for SCOTUS graph data
+
+-- Table of Supreme Court opinions from CourtListener
+CREATE TABLE IF NOT EXISTS opinions (
+    id INTEGER PRIMARY KEY,
+    docket TEXT,
+    case_name TEXT,
+    date_filed DATE,
+    citation TEXT,
+    absolute_url TEXT
+);
+
+-- Table capturing citation relationships between opinions
+CREATE TABLE IF NOT EXISTS citations (
+    source_id INTEGER NOT NULL REFERENCES opinions(id),
+    target_id INTEGER NOT NULL REFERENCES opinions(id)
+);

--- a/scotus-graph/scripts/ingest/relations.py
+++ b/scotus-graph/scripts/ingest/relations.py
@@ -1,0 +1,77 @@
+"""Extract citation relationships from CourtListener opinions.
+
+This script reads previously downloaded opinion JSON files from CourtListener
+and derives citation edges between opinions. The resulting pairs are written to
+`data/processed/courtlistener_citations.csv` with columns:
+
+- ``source_id`` – the citing opinion's CourtListener identifier
+- ``target_id`` – the cited opinion's CourtListener identifier
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+RAW_DIR = Path(__file__).resolve().parents[2] / "data" / "raw" / "courtlistener"
+PROCESSED_DIR = Path(__file__).resolve().parents[2] / "data" / "processed"
+
+# Pattern to extract opinion ID from CourtListener URLs
+ID_RE = re.compile(r"/opinion/(\d+)/")
+
+
+def extract_edges(opinion: Dict) -> List[Dict[str, int]]:
+    """Return citation edges for a single *opinion* object."""
+    src = opinion.get("id")
+    edges: List[Dict[str, int]] = []
+    for url in opinion.get("cites_to", []) or []:
+        match = ID_RE.search(url)
+        if match and src is not None:
+            edges.append({"source_id": int(src), "target_id": int(match.group(1))})
+    return edges
+
+
+def gather_edges(paths: Iterable[Path]) -> List[Dict[str, int]]:
+    """Collect citation edges from iterable of JSON *paths*."""
+    all_edges: List[Dict[str, int]] = []
+    for path in paths:
+        try:
+            opinion = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        all_edges.extend(extract_edges(opinion))
+    return all_edges
+
+
+def write_csv(rows: Iterable[Dict[str, int]], path: Path) -> None:
+    rows = list(rows)
+    if not rows:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=["source_id", "target_id"])
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out",
+        default=PROCESSED_DIR / "courtlistener_citations.csv",
+        type=Path,
+        help="Output CSV path",
+    )
+    args = parser.parse_args()
+
+    json_files = RAW_DIR.glob("opinion_*.json")
+    edges = gather_edges(json_files)
+    write_csv(edges, args.out)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Define relational and Neo4j schemas for Supreme Court opinions and citation edges.
- Add relations ingestion script to parse CourtListener JSON and produce citation edge CSVs.

## Testing
- `python -m py_compile scotus-graph/scripts/ingest/relations.py`
- `python scotus-graph/scripts/ingest/relations.py --out /tmp/citations_test.csv`


------
https://chatgpt.com/codex/tasks/task_e_68c73315ed088326aaa0824537c5334e