### PR TITLE
Add FastAPI API service with search and citation graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,2 @@
+"""API package for legal-directory service."""
+__all__ = []

--- a/api/database.py
+++ b/api/database.py
@@ -1,0 +1,33 @@
+"""Relational database integration using SQLAlchemy."""
+
+import os
+from sqlalchemy import Column, Date, Integer, String, Text, create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker, Session
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./cases.db")
+connect_args = {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+engine = create_engine(DATABASE_URL, connect_args=connect_args)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+
+class Case(Base):
+    __tablename__ = "cases"
+
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String, index=True)
+    text = Column(Text)
+    topic = Column(String, index=True)
+    date = Column(Date, index=True)
+
+
+def get_case(db: Session, case_id: int) -> Case | None:
+    return db.get(Case, case_id)
+
+
+def get_db() -> Session:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/api/graph.py
+++ b/api/graph.py
@@ -1,0 +1,24 @@
+"""Graph database integration using NetworkX."""
+
+import networkx as nx
+from typing import Dict, List
+
+
+class CitationGraph:
+    def __init__(self) -> None:
+        self.graph = nx.DiGraph()
+
+    def add_case(self, case_id: int) -> None:
+        self.graph.add_node(case_id)
+
+    def add_citation(self, source: int, target: int) -> None:
+        self.graph.add_edge(source, target)
+
+    def citations_for(self, case_id: int) -> Dict[str, List[int]]:
+        return {
+            "incoming": list(self.graph.predecessors(case_id)),
+            "outgoing": list(self.graph.successors(case_id)),
+        }
+
+
+citation_graph = CitationGraph()

--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,28 @@
+"""FastAPI service exposing case data and search."""
+
+from fastapi import Depends, FastAPI, HTTPException
+from sqlalchemy.orm import Session
+from typing import List
+
+from . import database, graph, schemas, search
+
+app = FastAPI(title="Legal Directory API")
+
+
+@app.get("/cases/{case_id}", response_model=schemas.Case)
+def read_case(case_id: int, db: Session = Depends(database.get_db)):
+    case = database.get_case(db, case_id)
+    if case is None:
+        raise HTTPException(status_code=404, detail="Case not found")
+    return case
+
+
+@app.get("/cases/{case_id}/citations", response_model=schemas.CitationResponse)
+def read_citations(case_id: int):
+    return graph.citation_graph.citations_for(case_id)
+
+
+@app.get("/search", response_model=List[schemas.Case])
+def search_endpoint(q: str, topic: str | None = None, date: str | None = None):
+    results = search.search_cases(q, topic=topic, date=date)
+    return [schemas.Case(**r) for r in results]

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import datetime as dt
+from pydantic import BaseModel, ConfigDict
+from typing import List
+
+
+class Case(BaseModel):
+    """Representation of a legal case."""
+    id: int
+    title: str
+    text: str
+    topic: str | None = None
+    date: dt.date | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class CitationResponse(BaseModel):
+    """Incoming and outgoing citations for a case."""
+    incoming: List[int]
+    outgoing: List[int]

--- a/api/search.py
+++ b/api/search.py
@@ -1,0 +1,22 @@
+"""Elasticsearch integration for case search."""
+
+import os
+from typing import Any, Dict, List
+from elasticsearch import Elasticsearch
+
+ELASTICSEARCH_URL = os.getenv("ELASTICSEARCH_URL", "http://localhost:9200")
+es_client = Elasticsearch(ELASTICSEARCH_URL)
+
+
+def search_cases(query: str, topic: str | None = None, date: str | None = None) -> List[Dict[str, Any]]:
+    """Search cases using Elasticsearch with optional filters."""
+    must: List[Dict[str, Any]] = [{"multi_match": {"query": query, "fields": ["title", "text"]}}]
+    filters: List[Dict[str, Any]] = []
+    if topic:
+        filters.append({"term": {"topic": topic}})
+    if date:
+        filters.append({"term": {"date": date}})
+
+    body = {"query": {"bool": {"must": must, "filter": filters}}}
+    response = es_client.search(index="cases", body=body)
+    return [hit["_source"] for hit in response["hits"]["hits"]]

--- a/api/tests/test_api.py
+++ b/api/tests/test_api.py
@@ -1,0 +1,69 @@
+import datetime
+import os
+import sys
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+# Ensure the package root is on the import path when tests are executed
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from api.main import app
+from api import database, graph, search
+
+
+# Setup file-based database and populate with a sample case
+engine = create_engine("sqlite:///./test.db", connect_args={"check_same_thread": False})
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+database.engine = engine
+database.SessionLocal = TestingSessionLocal
+database.Base.metadata.create_all(bind=engine)
+
+session = TestingSessionLocal()
+session.add(database.Case(id=1, title="Test Case", text="Lorem ipsum", topic="civil", date=datetime.date(2020, 1, 1)))
+session.commit()
+session.close()
+
+# Populate citation graph
+graph.citation_graph.graph.clear()
+graph.citation_graph.add_case(1)
+graph.citation_graph.add_case(2)
+graph.citation_graph.add_citation(2, 1)
+
+# Stub search service
+
+def fake_search_cases(query, topic=None, date=None):
+    return [
+        {
+            "id": 1,
+            "title": "Test Case",
+            "text": "Lorem ipsum",
+            "topic": "civil",
+            "date": datetime.date(2020, 1, 1),
+        }
+    ]
+
+
+search.search_cases = fake_search_cases
+
+client = TestClient(app)
+
+
+def test_get_case():
+    response = client.get("/cases/1")
+    assert response.status_code == 200
+    assert response.json()["title"] == "Test Case"
+
+
+def test_get_citations():
+    response = client.get("/cases/1/citations")
+    assert response.status_code == 200
+    assert response.json() == {"incoming": [2], "outgoing": []}
+
+
+def test_search():
+    response = client.get("/search", params={"q": "test"})
+    assert response.status_code == 200
+    body = response.json()
+    assert body[0]["id"] == 1


### PR DESCRIPTION
## Summary
- scaffold `api/` FastAPI service exposing case lookup, citation graph, and search endpoints
- integrate SQLAlchemy, NetworkX, and Elasticsearch for relational, graph, and text search data sources
- add tests for case retrieval, citation graph, and search endpoints

## Testing
- `pytest api/tests/test_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7348e4c688326b63214e1fc29045a