### PR TITLE
Add topic browsing and fix SCOTUS case search

### DIFF
--- a/case-search.html
+++ b/case-search.html
@@ -1,0 +1,142 @@
+---
+layout: page
+title: SCOTUS Case Search
+show_breadcrumbs: true
+breadcrumb_parent: Home
+breadcrumb_parent_url: /
+---
+
+<h1>SCOTUS Case Search</h1>
+
+<section id="category-section">
+  <h2>Browse by Topic</h2>
+  <div id="categories"></div>
+</section>
+
+<form id="search-form">
+  <input id="query" placeholder="Search case names or text…" required />
+  <button type="submit">Search</button>
+</form>
+
+<div id="results"></div>
+<div id="case-details"></div>
+
+<script>
+const categories = [
+  { code: 1, label: 'Criminal Procedure' },
+  { code: 2, label: 'Civil Rights' },
+  { code: 3, label: 'First Amendment' },
+  { code: 4, label: 'Due Process' },
+  { code: 5, label: 'Privacy' },
+  { code: 6, label: 'Attorneys' },
+  { code: 7, label: 'Unions' },
+  { code: 8, label: 'Economic Activity' },
+  { code: 9, label: 'Judicial Power' },
+  { code: 10, label: 'Federalism' },
+  { code: 11, label: 'Interstate Relations' },
+  { code: 12, label: 'Federal Taxation' },
+  { code: 13, label: 'Miscellaneous' },
+  { code: 14, label: 'Private Action' }
+];
+
+const form = document.getElementById('search-form');
+const resultsDiv = document.getElementById('results');
+const detailsDiv = document.getElementById('case-details');
+const categoryDiv = document.getElementById('categories');
+
+categories.forEach((cat) => {
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.textContent = cat.label;
+  btn.addEventListener('click', () => {
+    runSearch(`scdb_issue_area=${cat.code}`);
+  });
+  categoryDiv.appendChild(btn);
+});
+
+form.addEventListener('submit', (e) => {
+  e.preventDefault();
+  const q = document.getElementById('query').value.trim();
+  if (!q) return;
+  runSearch(`q=${encodeURIComponent(q)}`);
+});
+
+async function runSearch(queryString) {
+  resultsDiv.textContent = 'Searching...';
+  detailsDiv.innerHTML = '';
+  try {
+    const url = `https://www.courtlistener.com/api/rest/v3/opinions/?${queryString}&court=scotus&order_by=date_filed`;
+    const res = await fetch(url);
+    const data = await res.json();
+    renderResults(data.results || []);
+  } catch (err) {
+    console.error('Search failed', err);
+    resultsDiv.textContent = 'Error fetching results.';
+  }
+}
+
+function renderResults(cases) {
+  resultsDiv.innerHTML = '';
+  if (!cases.length) {
+    resultsDiv.textContent = 'No cases found.';
+    return;
+  }
+  const ul = document.createElement('ul');
+  cases.forEach((op) => {
+    const li = document.createElement('li');
+    const link = document.createElement('a');
+    const name = op.case_name || op.citation || `Case ${op.id}`;
+    link.href = '#';
+    link.textContent = `${name} (${op.date_filed || 'n.d.'})`;
+    link.addEventListener('click', (evt) => {
+      evt.preventDefault();
+      loadCase(op.id);
+    });
+    li.appendChild(link);
+    ul.appendChild(li);
+  });
+  resultsDiv.appendChild(ul);
+}
+
+async function loadCase(id) {
+  resultsDiv.innerHTML = '';
+  detailsDiv.textContent = 'Loading case...';
+  try {
+    const res = await fetch(`https://www.courtlistener.com/api/rest/v3/opinions/${id}/`);
+    const data = await res.json();
+    detailsDiv.innerHTML = '';
+    const title = data.case_name || data.citation || `Case ${id}`;
+    const header = document.createElement('h2');
+    header.textContent = title;
+    detailsDiv.appendChild(header);
+    const meta = document.createElement('p');
+    meta.textContent = `Decided: ${data.date_filed || 'Unknown'}`;
+    detailsDiv.appendChild(meta);
+    if (data.cites_to && data.cites_to.length) {
+      const h3 = document.createElement('h3');
+      h3.textContent = 'Citations';
+      detailsDiv.appendChild(h3);
+      const list = document.createElement('ul');
+      data.cites_to.forEach((cite) => {
+        if (cite.opinions && cite.opinions.length) {
+          const citedId = cite.opinions[0];
+          const li = document.createElement('li');
+          const a = document.createElement('a');
+          a.href = '#';
+          a.textContent = cite.cite;
+          a.addEventListener('click', (e) => {
+            e.preventDefault();
+            loadCase(citedId);
+          });
+          li.appendChild(a);
+          list.appendChild(li);
+        }
+      });
+      detailsDiv.appendChild(list);
+    }
+  } catch (err) {
+    console.error('Case load failed', err);
+    detailsDiv.textContent = 'Error loading case.';
+  }
+}
+</script>

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@ show_breadcrumbs: false
   <p>USAR primarily uses real life Federal Rules and other legal materials, but we have some caveats. So, we host a
     fully modified version of the Federal Rules here on this website.</p>
   <p>This website is created and maintained by the USAR Supreme Court.</p>
+  <p><a href="{{ site.baseurl }}/case-search.html">SCOTUS Case Search</a> – browse Supreme Court cases and explore citation relationships without running your own server.</p>
 
 
   <section class="homepage-section docket-section">


### PR DESCRIPTION
## Summary
- Add topic buttons that query CourtListener by Supreme Court Database issue area
- Fix API calls and field names so case searches return and display results reliably

## Testing
- `npm test` *(fails: Could not read package.json)*
- `cd web && npm test` *(fails: Missing script: "test")*
- `cd web && npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c6e118e42c83269ca900b2df2f68f7