### PR TITLE
Improve SCOTUS case search UI and error handling

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -955,3 +955,27 @@ li:hover .line-tools {
   font-family: inherit;
   margin-left: 0.25rem;
 }
+
+/* Case search styling */
+.category-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.category-btn {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  padding: 0.4rem 0.8rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 0.9rem;
+  transition: background 0.2s, color 0.2s, box-shadow 0.2s;
+}
+
+.category-btn:hover {
+  background: var(--link-hover-bg);
+  color: var(--link-hover-color);
+}

--- a/case-search.html
+++ b/case-search.html
@@ -10,7 +10,7 @@ breadcrumb_parent_url: /
 
 <section id="category-section">
   <h2>Browse by Topic</h2>
-  <div id="categories"></div>
+  <div id="categories" class="category-buttons"></div>
 </section>
 
 <form id="search-form">
@@ -22,6 +22,9 @@ breadcrumb_parent_url: /
 <div id="case-details"></div>
 
 <script>
+// CourtListener API token (hardcoded; replace with env var in production)
+const CL_TOKEN = '8671b4a853776a65c3d1393858c138e4951a246e';
+
 const categories = [
   { code: 1, label: 'Criminal Procedure' },
   { code: 2, label: 'Civil Rights' },
@@ -47,6 +50,7 @@ const categoryDiv = document.getElementById('categories');
 categories.forEach((cat) => {
   const btn = document.createElement('button');
   btn.type = 'button';
+  btn.className = 'category-btn';
   btn.textContent = cat.label;
   btn.addEventListener('click', () => {
     runSearch(`scdb_issue_area=${cat.code}`);
@@ -58,20 +62,33 @@ form.addEventListener('submit', (e) => {
   e.preventDefault();
   const q = document.getElementById('query').value.trim();
   if (!q) return;
-  runSearch(`q=${encodeURIComponent(q)}`);
+  // CourtListener expects `search` for full-text queries
+  runSearch(`search=${encodeURIComponent(q)}`);
 });
+
+function buildHeaders() {
+  return {
+    'User-Agent': 'USARLegalDirectory/1.0 (+https://github.com/USARscotus/legal-directory)',
+    'Authorization': `Token ${CL_TOKEN}`,
+  };
+}
 
 async function runSearch(queryString) {
   resultsDiv.textContent = 'Searching...';
   detailsDiv.innerHTML = '';
   try {
     const url = `https://www.courtlistener.com/api/rest/v3/opinions/?${queryString}&court=scotus&order_by=date_filed`;
-    const res = await fetch(url);
+    const res = await fetch(url, { headers: buildHeaders() });
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
     const data = await res.json();
-    renderResults(data.results || []);
+    if (!data.results || !Array.isArray(data.results) || !data.results.length) {
+      resultsDiv.textContent = 'No cases found.';
+      return;
+    }
+    renderResults(data.results);
   } catch (err) {
     console.error('Search failed', err);
-    resultsDiv.textContent = 'Error fetching results.';
+    resultsDiv.textContent = `Unable to fetch results: ${err.message}`;
   }
 }
 
@@ -102,7 +119,8 @@ async function loadCase(id) {
   resultsDiv.innerHTML = '';
   detailsDiv.textContent = 'Loading case...';
   try {
-    const res = await fetch(`https://www.courtlistener.com/api/rest/v3/opinions/${id}/`);
+    const res = await fetch(`https://www.courtlistener.com/api/rest/v3/opinions/${id}/`, { headers: buildHeaders() });
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
     const data = await res.json();
     detailsDiv.innerHTML = '';
     const title = data.case_name || data.citation || `Case ${id}`;
@@ -136,7 +154,7 @@ async function loadCase(id) {
     }
   } catch (err) {
     console.error('Case load failed', err);
-    detailsDiv.textContent = 'Error loading case.';
+    detailsDiv.textContent = `Unable to load case: ${err.message}`;
   }
 }
 </script>


### PR DESCRIPTION
## Summary
- Hardcode CourtListener API token directly in the search page and always send it with requests
- Drop unused COURTLISTENER_TOKEN config entry

## Testing
- `python -m pytest -q`
- `curl -s -D - -o /dev/null -H 'Authorization: Token 8671b4a853776a65c3d1393858c138e4951a246e' -H 'User-Agent: USARLegalDirectory/1.0 (+https://github.com/USARscotus/legal-directory)' https://www.courtlistener.com/api/rest/v3/opinions/?page_size=1` *(fails: HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c73e988d448326bffc11f633b77569