### PR TITLE
Expand case search filtering and metadata

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,8 +1,8 @@
 """FastAPI service exposing case data and search."""
 
-from fastapi import Depends, FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException, Query
 from sqlalchemy.orm import Session
-from typing import List
+from typing import Iterable, List
 
 from . import database, graph, schemas, search
 
@@ -23,6 +23,20 @@ def read_citations(case_id: int):
 
 
 @app.get("/search", response_model=List[schemas.Case])
-def search_endpoint(q: str, topic: str | None = None, date: str | None = None):
-    results = search.search_cases(q, topic=topic, date=date)
+def search_endpoint(
+    q: str | None = None,
+    category: str | None = None,
+    term: str | None = None,
+    year: int | None = None,
+    litigant: str | None = None,
+    keywords: Iterable[str] | None = Query(default=None),
+):
+    results = search.search_cases(
+        query=q,
+        category=category,
+        term=term,
+        year=year,
+        litigant=litigant,
+        keywords=keywords,
+    )
     return [schemas.Case(**r) for r in results]

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -12,6 +12,15 @@ class Case(BaseModel):
     text: str
     topic: str | None = None
     date: dt.date | None = None
+    citation: str | None = None
+    vote: str | None = None
+    opinions: List[str] | None = None
+    cites: List[int] | None = None
+    cited_by: List[int] | None = None
+    litigants: List[str] | None = None
+    term: str | None = None
+    year: int | None = None
+    category: str | None = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/api/search.py
+++ b/api/search.py
@@ -1,21 +1,49 @@
 """Elasticsearch integration for case search."""
 
 import os
-from typing import Any, Dict, List
+from typing import Any, Dict, Iterable, List
 from elasticsearch import Elasticsearch
 
 ELASTICSEARCH_URL = os.getenv("ELASTICSEARCH_URL", "http://localhost:9200")
 es_client = Elasticsearch(ELASTICSEARCH_URL)
 
 
-def search_cases(query: str, topic: str | None = None, date: str | None = None) -> List[Dict[str, Any]]:
-    """Search cases using Elasticsearch with optional filters."""
-    must: List[Dict[str, Any]] = [{"multi_match": {"query": query, "fields": ["title", "text"]}}]
+def _append_filter(filters: List[Dict[str, Any]], field: str, value: Any) -> None:
+    """Helper to append an Elasticsearch term filter when a value is provided."""
+    if value is not None:
+        filters.append({"term": {field: value}})
+
+
+def search_cases(
+    query: str | None = None,
+    *,
+    category: str | None = None,
+    term: str | None = None,
+    year: int | None = None,
+    litigant: str | None = None,
+    keywords: Iterable[str] | None = None,
+) -> List[Dict[str, Any]]:
+    """Search cases using Elasticsearch with rich filtering options.
+
+    By default only cases with ``status`` of ``decided`` are returned.
+    """
+
+    must: List[Dict[str, Any]] = []
+    if query:
+        must.append({"multi_match": {"query": query, "fields": ["title", "text", "keywords"]}})
+    if keywords:
+        must.append({"terms": {"keywords": list(keywords)}})
+    if not must:
+        must.append({"match_all": {}})
+
     filters: List[Dict[str, Any]] = []
-    if topic:
-        filters.append({"term": {"topic": topic}})
-    if date:
-        filters.append({"term": {"date": date}})
+    # Always exclude undecided cases
+    _append_filter(filters, "status", "decided")
+    _append_filter(filters, "topic", category)
+    _append_filter(filters, "term", term)
+    _append_filter(filters, "year", year)
+    if litigant:
+        filters.append({"match": {"litigants": litigant}})
 
     body = {"query": {"bool": {"must": must, "filter": filters}}}
     response = es_client.search(index="cases", body=body)

--- a/api/tests/test_api.py
+++ b/api/tests/test_api.py
@@ -31,9 +31,17 @@ graph.citation_graph.add_case(1)
 graph.citation_graph.add_case(2)
 graph.citation_graph.add_citation(2, 1)
 
-# Stub search service
+# Stub search service with extended fields
 
-def fake_search_cases(query, topic=None, date=None):
+def fake_search_cases(
+    query=None,
+    *,
+    category=None,
+    term=None,
+    year=None,
+    litigant=None,
+    keywords=None,
+):
     return [
         {
             "id": 1,
@@ -41,6 +49,15 @@ def fake_search_cases(query, topic=None, date=None):
             "text": "Lorem ipsum",
             "topic": "civil",
             "date": datetime.date(2020, 1, 1),
+            "citation": "1 U.S. 1",
+            "vote": "5-4",
+            "opinions": ["http://example.com/opinion"],
+            "cites": [2],
+            "cited_by": [3],
+            "litigants": ["Doe", "Smith"],
+            "term": "2020",
+            "year": 2020,
+            "category": "civil",
         }
     ]
 
@@ -67,3 +84,4 @@ def test_search():
     assert response.status_code == 200
     body = response.json()
     assert body[0]["id"] == 1
+    assert body[0]["citation"] == "1 U.S. 1"

--- a/search/schema.json
+++ b/search/schema.json
@@ -15,9 +15,20 @@
       "citation_id": {"type": "keyword"},
       "title": {"type": "text", "analyzer": "legal_text"},
       "text": {"type": "text", "analyzer": "legal_text"},
-      "topic_codes": {"type": "keyword"},
+      "topic": {"type": "keyword"},
+      "category": {"type": "keyword"},
       "court": {"type": "keyword"},
-      "date": {"type": "date"}
+      "date": {"type": "date"},
+      "status": {"type": "keyword"},
+      "term": {"type": "keyword"},
+      "year": {"type": "integer"},
+      "litigants": {"type": "text"},
+      "keywords": {"type": "keyword"},
+      "citation": {"type": "keyword"},
+      "vote": {"type": "keyword"},
+      "opinions": {"type": "keyword"},
+      "cites": {"type": "integer"},
+      "cited_by": {"type": "integer"}
     }
   }
 }


### PR DESCRIPTION
## Summary
- enhance Elasticsearch query with filters for category, term, year, litigant and keywords while excluding undecided cases
- expose new search parameters via FastAPI and enrich case schema with citation, vote, opinion links and citation lists
- extend index schema to store extra case metadata and update tests accordingly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c744b91dd88326ac824b101a00caf6