### PR TITLE
Expand case search filtering and metadata

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,8 +1,8 @@
 """FastAPI service exposing case data and search."""
 
-from fastapi import Depends, FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException, Query
 from sqlalchemy.orm import Session
-from typing import List
+from typing import Iterable, List
 
 from . import database, graph, schemas, search
 
@@ -23,6 +23,20 @@ def read_citations(case_id: int):
 
 
 @app.get("/search", response_model=List[schemas.Case])
-def search_endpoint(q: str, topic: str | None = None, date: str | None = None):
-    results = search.search_cases(q, topic=topic, date=date)
+def search_endpoint(
+    q: str | None = None,
+    category: str | None = None,
+    term: str | None = None,
+    year: int | None = None,
+    litigant: str | None = None,
+    keywords: Iterable[str] | None = Query(default=None),
+):
+    results = search.search_cases(
+        query=q,
+        category=category,
+        term=term,
+        year=year,
+        litigant=litigant,
+        keywords=keywords,
+    )
     return [schemas.Case(**r) for r in results]

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -12,6 +12,15 @@ class Case(BaseModel):
     text: str
     topic: str | None = None
     date: dt.date | None = None
+    citation: str | None = None
+    vote: str | None = None
+    opinions: List[str] | None = None
+    cites: List[int] | None = None
+    cited_by: List[int] | None = None
+    litigants: List[str] | None = None
+    term: str | None = None
+    year: int | None = None
+    category: str | None = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/api/search.py
+++ b/api/search.py
@@ -1,21 +1,49 @@
 """Elasticsearch integration for case search."""
 
 import os
-from typing import Any, Dict, List
+from typing import Any, Dict, Iterable, List
 from elasticsearch import Elasticsearch
 
 ELASTICSEARCH_URL = os.getenv("ELASTICSEARCH_URL", "http://localhost:9200")
 es_client = Elasticsearch(ELASTICSEARCH_URL)
 
 
-def search_cases(query: str, topic: str | None = None, date: str | None = None) -> List[Dict[str, Any]]:
-    """Search cases using Elasticsearch with optional filters."""
-    must: List[Dict[str, Any]] = [{"multi_match": {"query": query, "fields": ["title", "text"]}}]
+def _append_filter(filters: List[Dict[str, Any]], field: str, value: Any) -> None:
+    """Helper to append an Elasticsearch term filter when a value is provided."""
+    if value is not None:
+        filters.append({"term": {field: value}})
+
+
+def search_cases(
+    query: str | None = None,
+    *,
+    category: str | None = None,
+    term: str | None = None,
+    year: int | None = None,
+    litigant: str | None = None,
+    keywords: Iterable[str] | None = None,
+) -> List[Dict[str, Any]]:
+    """Search cases using Elasticsearch with rich filtering options.
+
+    By default only cases with ``status`` of ``decided`` are returned.
+    """
+
+    must: List[Dict[str, Any]] = []
+    if query:
+        must.append({"multi_match": {"query": query, "fields": ["title", "text", "keywords"]}})
+    if keywords:
+        must.append({"terms": {"keywords": list(keywords)}})
+    if not must:
+        must.append({"match_all": {}})
+
     filters: List[Dict[str, Any]] = []
-    if topic:
-        filters.append({"term": {"topic": topic}})
-    if date:
-        filters.append({"term": {"date": date}})
+    # Always exclude undecided cases
+    _append_filter(filters, "status", "decided")
+    _append_filter(filters, "topic", category)
+    _append_filter(filters, "term", term)
+    _append_filter(filters, "year", year)
+    if litigant:
+        filters.append({"match": {"litigants": litigant}})
 
     body = {"query": {"bool": {"must": must, "filter": filters}}}
     response = es_client.search(index="cases", body=body)

--- a/api/tests/test_api.py
+++ b/api/tests/test_api.py
@@ -31,9 +31,17 @@ graph.citation_graph.add_case(1)
 graph.citation_graph.add_case(2)
 graph.citation_graph.add_citation(2, 1)
 
-# Stub search service
+# Stub search service with extended fields
 
-def fake_search_cases(query, topic=None, date=None):
+def fake_search_cases(
+    query=None,
+    *,
+    category=None,
+    term=None,
+    year=None,
+    litigant=None,
+    keywords=None,
+):
     return [
         {
             "id": 1,
@@ -41,6 +49,15 @@ def fake_search_cases(query, topic=None, date=None):
             "text": "Lorem ipsum",
             "topic": "civil",
             "date": datetime.date(2020, 1, 1),
+            "citation": "1 U.S. 1",
+            "vote": "5-4",
+            "opinions": ["http://example.com/opinion"],
+            "cites": [2],
+            "cited_by": [3],
+            "litigants": ["Doe", "Smith"],
+            "term": "2020",
+            "year": 2020,
+            "category": "civil",
         }
     ]
 
@@ -67,3 +84,4 @@ def test_search():
     assert response.status_code == 200
     body = response.json()
     assert body[0]["id"] == 1
+    assert body[0]["citation"] == "1 U.S. 1"

--- a/case-search.html
+++ b/case-search.html
@@ -8,13 +8,15 @@ breadcrumb_parent_url: /
 
 <h1>SCOTUS Case Search</h1>
 
-<section id="category-section">
-  <h2>Browse by Topic</h2>
-  <div id="categories" class="category-buttons"></div>
-</section>
-
 <form id="search-form">
-  <input id="query" placeholder="Search case names or text…" required />
+  <input id="query" placeholder="Search case names or text…" />
+  <input id="litigant" placeholder="Litigant" />
+  <input id="term" placeholder="Term" />
+  <input id="year" type="number" placeholder="Year" min="1800" />
+  <input id="keywords" placeholder="Keywords (comma-separated)" />
+  <select id="category">
+    <option value="">Any Category</option>
+  </select>
   <button type="submit">Search</button>
 </form>
 
@@ -22,70 +24,87 @@ breadcrumb_parent_url: /
 <div id="case-details"></div>
 
 <script>
-
-const CL_TOKEN = '8671b4a853776a65c3d1393858c138e4951a246e';
-
 const categories = [
-  { code: 1, label: 'Criminal Procedure' },
-  { code: 2, label: 'Civil Rights' },
-  { code: 3, label: 'First Amendment' },
-  { code: 4, label: 'Due Process' },
-  { code: 5, label: 'Privacy' },
-  { code: 6, label: 'Attorneys' },
-  { code: 7, label: 'Unions' },
-  { code: 8, label: 'Economic Activity' },
-  { code: 9, label: 'Judicial Power' },
-  { code: 10, label: 'Federalism' },
-  { code: 11, label: 'Interstate Relations' },
-  { code: 12, label: 'Federal Taxation' },
-  { code: 13, label: 'Miscellaneous' },
-  { code: 14, label: 'Private Action' }
+  { code: '1', label: 'Criminal Procedure' },
+  { code: '2', label: 'Civil Rights' },
+  { code: '3', label: 'First Amendment' },
+  { code: '4', label: 'Due Process' },
+  { code: '5', label: 'Privacy' },
+  { code: '6', label: 'Attorneys' },
+  { code: '7', label: 'Unions' },
+  { code: '8', label: 'Economic Activity' },
+  { code: '9', label: 'Judicial Power' },
+  { code: '10', label: 'Federalism' },
+  { code: '11', label: 'Interstate Relations' },
+  { code: '12', label: 'Federal Taxation' },
+  { code: '13', label: 'Miscellaneous' },
+  { code: '14', label: 'Private Action' },
 ];
 
 const form = document.getElementById('search-form');
 const resultsDiv = document.getElementById('results');
 const detailsDiv = document.getElementById('case-details');
-const categoryDiv = document.getElementById('categories');
+const categorySelect = document.getElementById('category');
 
+// populate category select
 categories.forEach((cat) => {
-  const btn = document.createElement('button');
-  btn.type = 'button';
-  btn.className = 'category-btn';
-  btn.textContent = cat.label;
-  btn.addEventListener('click', () => {
-    runSearch(`scdb_issue_area=${cat.code}`);
-  });
-  categoryDiv.appendChild(btn);
+  const opt = document.createElement('option');
+  opt.value = cat.code;
+  opt.textContent = cat.label;
+  categorySelect.appendChild(opt);
 });
 
 form.addEventListener('submit', (e) => {
   e.preventDefault();
+  const params = new URLSearchParams();
   const q = document.getElementById('query').value.trim();
-  if (!q) return;
-  // CourtListener expects `search` for full-text queries
-  runSearch(`search=${encodeURIComponent(q)}`);
+  if (q) params.set('q', q);
+  const category = categorySelect.value;
+  if (category) params.set('category', category);
+  const term = document.getElementById('term').value.trim();
+  if (term) params.set('term', term);
+  const year = document.getElementById('year').value.trim();
+  if (year) params.set('year', year);
+  const litigant = document.getElementById('litigant').value.trim();
+  if (litigant) params.set('litigant', litigant);
+  const keywords = document.getElementById('keywords').value.trim();
+  if (keywords) params.set('keywords', keywords);
+  runSearch(params);
+  history.pushState(null, '', `${window.location.pathname}?${params.toString()}`);
 });
 
-function buildHeaders() {
-  return {
-    'User-Agent': 'USARLegalDirectory/1.0 (+https://github.com/USARscotus/legal-directory)',
-    'Authorization': `Token ${CL_TOKEN}`,
-  };
+window.addEventListener('popstate', initFromUrl);
+
+function initFromUrl() {
+  const params = new URLSearchParams(window.location.search);
+  const caseId = params.get('case');
+  if (caseId) {
+    loadCase(caseId);
+    return;
+  }
+  ['q','category','term','year','litigant','keywords'].forEach((key) => {
+    const val = params.get(key);
+    if (val) {
+      const elemId = key === 'q' ? 'query' : key;
+      const el = document.getElementById(elemId);
+      if (el) el.value = val;
+    }
+  });
+  if (params.toString()) {
+    runSearch(params);
+  }
 }
 
-async function runSearch(queryString) {
+initFromUrl();
+
+async function runSearch(params) {
   resultsDiv.textContent = 'Searching...';
   detailsDiv.innerHTML = '';
   try {
-    const url = `https://www.courtlistener.com/api/rest/v3/opinions/?${queryString}&court=scotus&order_by=date_filed`;
-    const res = await fetch(url, { headers: buildHeaders() });
+    const res = await fetch(`/api/search?${params.toString()}`);
     if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
     const data = await res.json();
-    if (!data.results || !Array.isArray(data.results) || !data.results.length) {
-      resultsDiv.textContent = 'No cases found.';
-      return;
-    }
-    renderResults(data.results);
+    renderResults(data);
   } catch (err) {
     console.error('Search failed', err);
     resultsDiv.textContent = `Unable to fetch results: ${err.message}`;
@@ -94,22 +113,22 @@ async function runSearch(queryString) {
 
 function renderResults(cases) {
   resultsDiv.innerHTML = '';
-  if (!cases.length) {
+  if (!cases || !cases.length) {
     resultsDiv.textContent = 'No cases found.';
     return;
   }
   const ul = document.createElement('ul');
-  cases.forEach((op) => {
+  cases.forEach((c) => {
     const li = document.createElement('li');
-    const link = document.createElement('a');
-    const name = op.case_name || op.citation || `Case ${op.id}`;
-    link.href = '#';
-    link.textContent = `${name} (${op.date_filed || 'n.d.'})`;
-    link.addEventListener('click', (evt) => {
-      evt.preventDefault();
-      loadCase(op.id);
+    const btn = document.createElement('button');
+    btn.textContent = `${c.title} (${c.citation || c.year || 'n.d.'})`;
+    btn.addEventListener('click', () => {
+      loadCase(c.id);
+      const params = new URLSearchParams(window.location.search);
+      params.set('case', c.id);
+      history.pushState(null, '', `${window.location.pathname}?${params.toString()}`);
     });
-    li.appendChild(link);
+    li.appendChild(btn);
     ul.appendChild(li);
   });
   resultsDiv.appendChild(ul);
@@ -119,36 +138,71 @@ async function loadCase(id) {
   resultsDiv.innerHTML = '';
   detailsDiv.textContent = 'Loading case...';
   try {
-    const res = await fetch(`https://www.courtlistener.com/api/rest/v3/opinions/${id}/`, { headers: buildHeaders() });
+    const res = await fetch(`/api/cases/${id}`);
     if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
     const data = await res.json();
     detailsDiv.innerHTML = '';
-    const title = data.case_name || data.citation || `Case ${id}`;
     const header = document.createElement('h2');
-    header.textContent = title;
+    header.textContent = `${data.title}${data.citation ? ' – ' + data.citation : ''}`;
     detailsDiv.appendChild(header);
     const meta = document.createElement('p');
-    meta.textContent = `Decided: ${data.date_filed || 'Unknown'}`;
+    const datePart = data.date ? `Decided: ${data.date}` : 'Decided: Unknown';
+    const votePart = data.vote ? ` | Vote: ${data.vote}` : '';
+    meta.textContent = `${datePart}${votePart}`;
     detailsDiv.appendChild(meta);
-    if (data.cites_to && data.cites_to.length) {
+    if (data.opinions && data.opinions.length) {
       const h3 = document.createElement('h3');
-      h3.textContent = 'Citations';
+      h3.textContent = 'Opinions';
       detailsDiv.appendChild(h3);
       const list = document.createElement('ul');
-      data.cites_to.forEach((cite) => {
-        if (cite.opinions && cite.opinions.length) {
-          const citedId = cite.opinions[0];
-          const li = document.createElement('li');
-          const a = document.createElement('a');
-          a.href = '#';
-          a.textContent = cite.cite;
-          a.addEventListener('click', (e) => {
-            e.preventDefault();
-            loadCase(citedId);
-          });
-          li.appendChild(a);
-          list.appendChild(li);
-        }
+      data.opinions.forEach((url) => {
+        const li = document.createElement('li');
+        const a = document.createElement('a');
+        a.href = url;
+        a.textContent = url;
+        a.target = '_blank';
+        li.appendChild(a);
+        list.appendChild(li);
+      });
+      detailsDiv.appendChild(list);
+    }
+    if (data.cites && data.cites.length) {
+      const h3 = document.createElement('h3');
+      h3.textContent = 'Cites To';
+      detailsDiv.appendChild(h3);
+      const list = document.createElement('ul');
+      data.cites.forEach((cid) => {
+        const li = document.createElement('li');
+        const btn = document.createElement('button');
+        btn.textContent = `Case ${cid}`;
+        btn.addEventListener('click', () => {
+          loadCase(cid);
+          const params = new URLSearchParams(window.location.search);
+          params.set('case', cid);
+          history.pushState(null, '', `${window.location.pathname}?${params.toString()}`);
+        });
+        li.appendChild(btn);
+        list.appendChild(li);
+      });
+      detailsDiv.appendChild(list);
+    }
+    if (data.cited_by && data.cited_by.length) {
+      const h3 = document.createElement('h3');
+      h3.textContent = 'Cited By';
+      detailsDiv.appendChild(h3);
+      const list = document.createElement('ul');
+      data.cited_by.forEach((cid) => {
+        const li = document.createElement('li');
+        const btn = document.createElement('button');
+        btn.textContent = `Case ${cid}`;
+        btn.addEventListener('click', () => {
+          loadCase(cid);
+          const params = new URLSearchParams(window.location.search);
+          params.set('case', cid);
+          history.pushState(null, '', `${window.location.pathname}?${params.toString()}`);
+        });
+        li.appendChild(btn);
+        list.appendChild(li);
       });
       detailsDiv.appendChild(list);
     }

--- a/search/schema.json
+++ b/search/schema.json
@@ -15,9 +15,20 @@
       "citation_id": {"type": "keyword"},
       "title": {"type": "text", "analyzer": "legal_text"},
       "text": {"type": "text", "analyzer": "legal_text"},
-      "topic_codes": {"type": "keyword"},
+      "topic": {"type": "keyword"},
+      "category": {"type": "keyword"},
       "court": {"type": "keyword"},
-      "date": {"type": "date"}
+      "date": {"type": "date"},
+      "status": {"type": "keyword"},
+      "term": {"type": "keyword"},
+      "year": {"type": "integer"},
+      "litigants": {"type": "text"},
+      "keywords": {"type": "keyword"},
+      "citation": {"type": "keyword"},
+      "vote": {"type": "keyword"},
+      "opinions": {"type": "keyword"},
+      "cites": {"type": "integer"},
+      "cited_by": {"type": "integer"}
     }
   }
 }


### PR DESCRIPTION
## Summary
- replace static CourtListener queries with internal API
- add inputs for category, term, year, litigant, and keywords and render results as buttons
- show votes, opinions, and citation relationships with shareable URLs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c744b91dd88326ac824b101a00caf6