### PR TITLE
Fix case search API path for subdirectory deployments

### DIFF
--- a/case-search.html
+++ b/case-search.html
@@ -108,7 +108,7 @@ async function runSearch(params) {
   resultsDiv.textContent = 'Searching...';
   detailsDiv.innerHTML = '';
   try {
-    const res = await fetch(`/api/search?${params.toString()}`);
+    const res = await fetch(`api/search?${params.toString()}`);
     if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
     const data = await res.json();
     renderResults(data);
@@ -149,7 +149,7 @@ async function loadCase(id) {
   resultsDiv.innerHTML = '';
   detailsDiv.textContent = 'Loading case...';
   try {
-    const res = await fetch(`/api/cases/${id}`);
+      const res = await fetch(`api/cases/${id}`);
     if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
     const data = await res.json();
     detailsDiv.innerHTML = '';


### PR DESCRIPTION
## Summary
- use relative API URLs in case search to avoid 404s when site served from a subdirectory

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c75a72d38c8326896c5942a0a597c2