### PR TITLE
Fix search index to include all site pages

### DIFF
--- a/search.html
+++ b/search.html
@@ -66,7 +66,9 @@ breadcrumb_parent_url: /
 
         const filtered = results.filter(r => {
             const match = docMap[r.ref];
-            return match && selected.includes(match.collection);
+            if (!match) return false;
+            if (!match.collection) return true;
+            return selected.includes(match.collection);
         });
 
         if (filtered.length > 0) {

--- a/search.json
+++ b/search.json
@@ -3,14 +3,21 @@ layout: null
 permalink: /search.json
 ---
 [
-{% assign docs = site.html_pages %}
-{% assign valid_docs = "" | split: "" %}
-{% for doc in docs %}
-  {% unless doc.layout == "page" or doc.search_exclude == true %}
-    {% assign valid_docs = valid_docs | push: doc %}
+{% assign combined_docs = "" | split: "" %}
+{% for doc in site.html_pages %}
+  {% unless doc.search_exclude == true %}
+    {% assign combined_docs = combined_docs | push: doc %}
   {% endunless %}
 {% endfor %}
-{% for doc in valid_docs %}
+{% for collection in site.collections %}
+  {% for doc in collection.docs %}
+    {% unless doc.search_exclude == true %}
+      {% assign combined_docs = combined_docs | push: doc %}
+    {% endunless %}
+  {% endfor %}
+{% endfor %}
+{% assign unique_docs = combined_docs | uniq %}
+{% for doc in unique_docs %}
   {% assign parts = doc.url | downcase | split: '/' %}
   {% assign section = "" %}
   {% for p in parts %}


### PR DESCRIPTION
## Summary
- include all html pages and collection documents when generating the search index
- allow search results without a rule collection to bypass collection filters so they appear in results

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68e58c9b119483269d11f8170e874e6e