### PR TITLE
Fix rule tools DOMContentLoaded closure

### DIFF
--- a/assets/rule-tools.js
+++ b/assets/rule-tools.js
@@ -36,7 +36,6 @@ document.addEventListener('DOMContentLoaded', function() {
     navigator.clipboard.writeText(ruleCitationBase);
   });
   titleEl.appendChild(citeBtn);
-  });
 
   function extractCitationPart(el) {
     const parts = [];


### PR DESCRIPTION
## Summary
- remove the premature closure of the DOMContentLoaded handler in `assets/rule-tools.js` so the formatting script stays valid

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e595245514832692f94084f819b4ae